### PR TITLE
Rename edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Summary
 * [Getting started](content/docs/getting-started.md)
 * [Programing Languages](content/docs/programing-languages.md)
 * [User Defined Language System](content/docs/user-defined-language-system.md)
-* [Edition](content/docs/edition.md)
+* [Editing](content/docs/editing.md)
 * [Searching](content/docs/searching.md)
 * [Session](content/docs/session.md)
 * [Macros](content/docs/macros.md)

--- a/content/docs/editing.md
+++ b/content/docs/editing.md
@@ -1,5 +1,5 @@
 ---
-title: Edition
+title: Editing
 weight: 30
 ---
 


### PR DESCRIPTION
Standard usage is for "edition" is more like "version" or "publishing unit" (like the third edition of a dictionary), whereas "editing" is the act or process of making edits.