### PR TITLE
Find in Files (NPP v7.8.2)

### DIFF
--- a/content/docs/searching.md
+++ b/content/docs/searching.md
@@ -183,7 +183,7 @@ The popup window has a parameter not available in the searches described earlier
 
 ### Find in Files
 
-Find in Files allows both finding and replacing. You can choose an extension filter (**Filters:**), the containing folder (**Directory:**), and whether to also process hidden files or subfolders. The filter list is a space separated list of wildcard expressions that cmd.exe can understand, like "*.doc", "*.*" or "foo.*". Note however that the PathMatchSpec() Windows API is being used, as its behavior departs from cmd.exe wildcard parsing sometimes.
+Find in Files allows both finding and replacing. You can choose an extension filter (**Filters:**), the containing folder (**Directory:**), and whether to also process hidden files or subfolders. The filter list is a space separated list of wildcard expressions that cmd.exe can understand, like `*.doc *.* foo.*`.   As of Notepad++ v7.8.2, you can also exclude certain file patterns by prefixing the filter with a `!`; for example, **Filters:  `!*.bin`** will exclude files matching `*.bin` from the search results.)  Please note however that the PathMatchSpec() Windows API is being used, as its behavior departs from cmd.exe wildcard parsing sometimes.  As
 
 How the default folder changes is controlled by the `fifFolderFollowsDoc` settings in `config.xml`, which is set by the **Follow current doc** checkbox in the dialog.
 

--- a/content/docs/searching.md
+++ b/content/docs/searching.md
@@ -183,9 +183,14 @@ The popup window has a parameter not available in the searches described earlier
 
 ### Find in Files
 
-Find in Files allows both finding and replacing. You can choose an extension filter (**Filters:**), the containing folder (**Directory:**), and whether to also process hidden files or subfolders. The filter list is a space separated list of wildcard expressions that cmd.exe can understand, like `*.doc *.* foo.*`.   As of Notepad++ v7.8.2, you can also exclude certain file patterns by prefixing the filter with a `!`; for example, **Filters:  `!*.bin`** will exclude files matching `*.bin` from the search results.)  Please note however that the PathMatchSpec() Windows API is being used, as its behavior departs from cmd.exe wildcard parsing sometimes.
+Find in Files allows both finding and replacing. You can choose an extension filter (**Filters:**), the containing folder (**Directory:**), and whether to also process hidden files or subfolders. 
 
-How the default folder changes is controlled by the `fifFolderFollowsDoc` settings in `config.xml`, which is set by the **Follow current doc** checkbox in the dialog.
+The **Filters** list is a space-separated list of wildcard expressions that cmd.exe can understand, like `*.doc *.* foo.*`.   As of Notepad++ v7.8.2, you can also exclude certain file patterns by prefixing the filter with a `!`; for example, **Filters:  `!*.bin`** will exclude files matching `*.bin` from the search results.)  Please note however that the PathMatchSpec() Windows API is being used, as its behavior departs from cmd.exe wildcard parsing sometimes.
+
+The **Directory** is the containing folder for where to search.  It has three options that affect it's behavior: 
+* **☐ Follow current doc** ⇒ if enabled, it will default to searching the folder that contains the current active document (this sets the `fifFolderFollowsDoc` in `config.xml`).
+* **☐ In all sub-folders** ⇒ if enabled, it will recursively search sub-folders of the given folder.
+* **☐ In hidden folders** ⇒ if enabled, it will search hidden sub-folders as well as normally-visible sub-folders.
 
 ### Highlighting and bookmarking
 

--- a/content/docs/searching.md
+++ b/content/docs/searching.md
@@ -183,7 +183,7 @@ The popup window has a parameter not available in the searches described earlier
 
 ### Find in Files
 
-Find in Files allows both finding and replacing. You can choose an extension filter (**Filters:**), the containing folder (**Directory:**), and whether to also process hidden files or subfolders. The filter list is a space separated list of wildcard expressions that cmd.exe can understand, like `*.doc *.* foo.*`.   As of Notepad++ v7.8.2, you can also exclude certain file patterns by prefixing the filter with a `!`; for example, **Filters:  `!*.bin`** will exclude files matching `*.bin` from the search results.)  Please note however that the PathMatchSpec() Windows API is being used, as its behavior departs from cmd.exe wildcard parsing sometimes.  As
+Find in Files allows both finding and replacing. You can choose an extension filter (**Filters:**), the containing folder (**Directory:**), and whether to also process hidden files or subfolders. The filter list is a space separated list of wildcard expressions that cmd.exe can understand, like `*.doc *.* foo.*`.   As of Notepad++ v7.8.2, you can also exclude certain file patterns by prefixing the filter with a `!`; for example, **Filters:  `!*.bin`** will exclude files matching `*.bin` from the search results.)  Please note however that the PathMatchSpec() Windows API is being used, as its behavior departs from cmd.exe wildcard parsing sometimes.
 
 How the default folder changes is controlled by the `fifFolderFollowsDoc` settings in `config.xml`, which is set by the **Follow current doc** checkbox in the dialog.
 


### PR DESCRIPTION
add in the example of the new v7.8.2 feature 
>Add find in files filter excluding ability.

where now `!*.bin` will exclude `*.bin` from the searched files.

Also, rephrase that paragraph so it's obvious what applies to **Filters** and what applies to **Directory**.