### PR TITLE
Suggest to modify this description

### DIFF
--- a/content/docs/binary-translation.md
+++ b/content/docs/binary-translation.md
@@ -26,7 +26,11 @@ For modifying an existing xml files, here is the way to visualize your modificat
 <div>
 
 <div align="center" style="margin: 20px; display: inline-block;">
-<a href="https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/chinese.xml" target="_blank"> <img src="/docs/images/flags/fTaiwan.png" alt="" border="0" /><br /> Chinese</a>
+<a href="https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/chineseSimplified.xml" target="_blank"><img src="/docs/images/flags/fChina.png" alt="" border="0" /><br /> Chinese Simplified</a> 
+</div>
+
+<div align="center" style="margin: 20px; display: inline-block;">
+<a href="https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/chinese.xml" target="_blank"> <img src="/docs/images/flags/fTaiwan.png" alt="" border="0" /><br /> Chinese Traditional</a>
 </div>
 
 <div align="center" style="margin: 20px; display: inline-block;">
@@ -47,10 +51,6 @@ For modifying an existing xml files, here is the way to visualize your modificat
 
 <div align="center" style="margin: 20px; display: inline-block;">
 <a href="https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/dutch.xml" target="_blank"><img src="/docs/images/flags/fNetherlands.png" alt="" border="0" /><br /> Dutch</a> 
-</div>
-
-<div align="center" style="margin: 20px; display: inline-block;">
-<a href="https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/chineseSimplified.xml" target="_blank"><img src="/docs/images/flags/fChina.png" alt="" border="0" /><br /> Chinese Simplified</a> 
 </div>
 
 <div align="center" style="margin: 20px; display: inline-block;">

--- a/content/docs/binary-translation.md
+++ b/content/docs/binary-translation.md
@@ -26,10 +26,6 @@ For modifying an existing xml files, here is the way to visualize your modificat
 <div>
 
 <div align="center" style="margin: 20px; display: inline-block;">
-<a href="https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/chineseSimplified.xml" target="_blank"><img src="/docs/images/flags/fChina.png" alt="" border="0" /><br /> Chinese Simplified</a> 
-</div>
-
-<div align="center" style="margin: 20px; display: inline-block;">
 <a href="https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/chinese.xml" target="_blank"> <img src="/docs/images/flags/fTaiwan.png" alt="" border="0" /><br /> Chinese Traditional</a>
 </div>
 
@@ -51,6 +47,10 @@ For modifying an existing xml files, here is the way to visualize your modificat
 
 <div align="center" style="margin: 20px; display: inline-block;">
 <a href="https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/dutch.xml" target="_blank"><img src="/docs/images/flags/fNetherlands.png" alt="" border="0" /><br /> Dutch</a> 
+</div>
+
+<div align="center" style="margin: 20px; display: inline-block;">
+<a href="https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/chineseSimplified.xml" target="_blank"><img src="/docs/images/flags/fChina.png" alt="" border="0" /><br /> Chinese Simplified</a> 
 </div>
 
 <div align="center" style="margin: 20px; display: inline-block;">


### PR DESCRIPTION
Current description may have issues.

Generally speaking, "chinese" refers to the official language of China, but now, in this usermanual, use "Chinese" refer to the language used in Taiwan. So it is recommended to stay neutral, changed to use the full description.