### PR TITLE
Clarify Count now that it is influenced by directionality

### DIFF
--- a/content/docs/searching.md
+++ b/content/docs/searching.md
@@ -51,7 +51,7 @@ The various action buttons available include:
 
 * **Find Next**: Finds the next matching text
     * **☐** This checkbox changes the single **Find Next** button into **<<** and **>>** buttons, which are "Search backward" and "Search forward" (hovering over this checkbox with the mouse will, after a slight pause in movement, pop up a tooltip indicating "2 find buttons mode")
-* **Count**: Counts how many matches are in the entire document, or possibly "In Selection", and shows that count in the message section at the bottom of the dialog box
+* **Count**: Counts how many matches are in the entire document, or in the specified direction, or possibly "In Selection", and shows that count in the message section at the bottom of the dialog box
 * **Find All in All Opened Documents**: Lists all the search-results in a new **Find result** window; searches through all the file buffers currently open in Notepad++
 * **Find All in Current Document**: Lists all the search-results in a new **Find result** window; only searches the active document buffer
 * **Close**: Closes the search dialog
@@ -183,11 +183,11 @@ The popup window has a parameter not available in the searches described earlier
 
 ### Find in Files
 
-Find in Files allows both finding and replacing. You can choose an extension filter (**Filters:**), the containing folder (**Directory:**), and whether to also process hidden files or subfolders. 
+Find in Files allows both finding and replacing. You can choose an extension filter (**Filters:**), the containing folder (**Directory:**), and whether to also process hidden files or subfolders.
 
 The **Filters** list is a space-separated list of wildcard expressions that cmd.exe can understand, like `*.doc foo.*`.   If you have a blank filter, it is implied to be `*.*`.  As of Notepad++ v7.8.2, you can also exclude certain file patterns by prefixing the filter with a `!`; for example, **Filters:  `!*.bin *.*`** will exclude files matching `*.bin` from the search results, but include any other filename; if you have at least one exclusion in your filter, you need to have at least one inclusion in your filter, otherwise it excludes files from the 0 matched inclusion files, resulting in no files matched, which probably isn't what you want.  Please also note that the PathMatchSpec() Windows API is being used, as its behavior departs from cmd.exe wildcard parsing sometimes.
 
-The **Directory** is the containing folder for where to search.  It has three options that affect it's behavior: 
+The **Directory** is the containing folder for where to search.  It has three options that affect it's behavior:
 * **☐ Follow current doc** ⇒ if enabled, it will default to searching the folder that contains the current active document (this sets the `fifFolderFollowsDoc` in `config.xml`).
 * **☐ In all sub-folders** ⇒ if enabled, it will recursively search sub-folders of the given folder.
 * **☐ In hidden folders** ⇒ if enabled, it will search hidden sub-folders as well as normally-visible sub-folders.


### PR DESCRIPTION
Update documentation for Notepad++ commit # 7917 which adds influence to Count command in Find dialog:  Backward-direction and Wrap-around now affect Count'ing.

