### PR TITLE
Add license page link to README summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Summary
 * [Ghost Typing](content/docs/binary-translation.md)
 * [Upgrading](content/docs/upgrading.md)
 * [Other Resources](content/docs/other-resources.md)
+* [Copyright & License](content/docs/license.md)
 
 
 How to test site locally

--- a/content/docs/command-prompt.md
+++ b/content/docs/command-prompt.md
@@ -4,7 +4,8 @@ linktitle: Command prompt
 weight: 120
 ---
 
-Notepad++ supports a few command line parameters to control its startup. The syntax is (case sensitive):
+Notepad++ supports various case-sensitive command line parameters
+to control its startup and affect its behavior.
 
 ## Help usage
 
@@ -24,7 +25,7 @@ notepad++ [--help] [-multiInst] [-noPlugin] [-l<lang>] [-n<line>] [-c<column>]
   Notepad++ simultaneously.
 * `-noPlugin`: Launch Notepad++ without loading any plugin.
 * `-l`: Open file or display ghost typing with syntax highlighting of choice.
-  *Language* is a short identifier string, of which the following are allowed:  
+  *Language* is a short identifier string, of which the following are allowed:
   `normal`, `php`, `c`, `cpp`, `cs`, `objc`, `d`, `java`, `rc`, `html`, `xml`,
   `makefile`, `pascal`, `batch`, `ini`, `nfo`, `asp`, `sql`, `vb`, `javascript`,
   `css`, `perl`, `python`, `lua`, `tex`, `cobol`, `fortran`, `bash`,
@@ -54,8 +55,33 @@ notepad++ [--help] [-multiInst] [-noPlugin] [-l<lang>] [-n<line>] [-c<column>]
 * `filepath`: file or folder name to open (absolute or relative path name)
 
 
-The order of the options is not important.
+The order of the options is not important.  Brackets indicate that the options
+are not required, and are _not_ part of the command-line argument.  The number
+of hyphens is significant, and the options are case sensitive.
 
 For compatibility, Notepad++ will first try to identify the entire command line
 as a filename, even if it is unquoted. It is however not recommended to do this,
-always quote the filename.
+as you should always quote the filename.
+
+This help usage list can be accessed inside Notepad++ using the `--help` command
+line argument, or using the **?**-menu's **Command Line Arguments** entry.
+
+## Additional Options
+
+There are other Notepad++ command-line options which aren't included in the help
+usage list.  These are intended for advanced usage or other special circumstances.
+
+* `-notepadStyleCmdline`: When you follow the instructions in
+  [Other Resources > Notepad Replacement](../other-resources/#notepad-replacement),
+  to replace Windows' builtin `notepad.exe` with Notepad++, Windows will try to pass `/p` or `/P` as
+  a command-line option when you try to print the file from the Explorer Context menu.
+  Enabling this option allows Notepad++ to recognize that option, and convert it internally
+  to the official `-quickPrint` option.
+* `-z`: Strips out any command line arguments found after this option. Aside from its use
+  in the [Notepad Replacement](../other-resources/#notepad-replacement), this can be used
+  to pass options to plugins, by placing the plugin's options after the `-z` in the command
+  line, and having the plugin parse through the command line to determine if the option is present.
+  An example of this technique can be found in
+  [this Notepad++ Community Forum post](https://community.notepad-plus-plus.org/post/52805),
+  where a script run using the PythonScript plugin is able to use a command-line option
+  to affect the script's behavior.


### PR DESCRIPTION
per https://github.com/notepad-plus-plus/npp-usermanual/commit/38173eeb73afe5fa9789cd6f3a91c106f569dde6#commitcomment-41958939, I forgot to make a link in README.md to the new license.md page, so adding that.

Since the previous PR was already merged, done under a new PR.