### PR TITLE
Add a notice for function list

### DIFF
--- a/content/docs/function-list.md
+++ b/content/docs/function-list.md
@@ -26,6 +26,8 @@ A function parser contains only a function node.
 A class parser contains only a classRange node.
 A mix parser contains both function and classRange nodes.
 
+*Note that* ***RegEx look behind operations*** *dosen't work with the parser.*
+
 ### Function parser
 In function node it contains:
 

--- a/content/docs/function-list.md
+++ b/content/docs/function-list.md
@@ -26,7 +26,7 @@ A function parser contains only a function node.
 A class parser contains only a classRange node.
 A mix parser contains both function and classRange nodes.
 
-*Note that* ***RegEx look behind operations*** *dosen't work with the parser.*
+*Note that* ***RegEx look behind operations*** *don't work with the parser.*
 
 ### Function parser
 In function node it contains:


### PR DESCRIPTION
Add a notice to not use RegEx look behind operations for function list.
Please check:
https://github.com/notepad-plus-plus/notepad-plus-plus/pull/9008#issuecomment-715498220
for further information.