### PR TITLE
Update for copying styled or marked text features

### DIFF
--- a/content/docs/searching.md
+++ b/content/docs/searching.md
@@ -204,6 +204,8 @@ In either case, the Mark All button will perform the marking.
 
 To control whether highlighting or bookmarks accumulate over successive searches, use the **Clear all marks** button to remove marks, or check **Purge for each search** for this action to be performed automatically on each search.  When the **Clear all marks** button is pressed, any marked text will have the marking background coloring removed; additionally, any bookmarks previously set will be removed if the **Bookmark line** checkbox is checked.
 
+Once some text in a document is marked, it may be copied to the clipboard by pressing the **Copy Marked Text** button.  This feature is also invocable from the Search menu, and in order to be used in a macro, the Search menu version of this copy command must be used.
+
 Highlighting is also available in Incremental search, and the style setting is Settings -&gt; Styler Configurator -&gt; Global Styles , Incremental Highlighting instead.
 
 ## Dialog-free search/mark actions
@@ -224,7 +226,14 @@ Please note that "selected" refers to the contents of the active stream selectio
 
 ### Highlighting
 
-Use the Mark All or Unmark All submenus of the Search menu to mark all occurrences of the word the caret is in. The settings for each of the 5 available styles are Settings -&gt; Styler Configurator -&gt; Global Styles , Mark style #. You can also cause all occurrences of the word at the caret to get dynamically highlighted if you enable Smart Highlighting; the mark style then is Settings -&gt; Styler Configurator -&gt; Global Styles , Smart Highlighting. You may choose there whether the matching should be sensitive to case.
+Use the Mark All or Unmark All submenus of the Search menu to mark all occurrences of the selected text or word the caret is in if there is no active selection.  You have a choice of five different colors in which to highlight/mark text in this manner.
+
+The settings for each of the 5 available styles are Settings -&gt; Styler Configurator -&gt; Global Styles , Mark style #.
+
+If you've highlighted some groups of text in this manner, and you wish to copy those sections, the Copy Styled Text submenu of the Search menu will allow you to do that.
+
+You can also cause all occurrences of the word at the caret to get dynamically highlighted if you enable Smart Highlighting; the mark style then is Settings -&gt; Styler Configurator -&gt; Global Styles , Smart Highlighting. You may choose there whether the matching should be sensitive to case.
+
 You enable smart highlighting through Settings -&gt; Preferences -&gt; MISC -&gt; Smart highlighting, Enable smart highlighting. By default, the highlighting is case insensitive, which may be a problem sometimes. Then just toggle Settings -&gt; Preferences -&gt; MISC -&gt; Highlighting is case sensitive on.  (See also [Style Configurator](../preferences/#style-configurator) and [Preferences](../preferences/#preferences).)
 
 


### PR DESCRIPTION
Reference these N++ code items for this documentation change:

* commits into master: 
https://github.com/notepad-plus-plus/notepad-plus-plus/commit/013305f306039998c0ba8a85c03238843879b6cf
https://github.com/notepad-plus-plus/notepad-plus-plus/commit/9ab554a1291f83668eb728cb499f2a009b98f81a

* PR: 
https://github.com/notepad-plus-plus/notepad-plus-plus/pull/8867 "Add ability to copy marked text to the clipboard"
https://github.com/notepad-plus-plus/notepad-plus-plus/pull/8964 "Add copy styled text to clipboard capability"

* issues:
https://github.com/notepad-plus-plus/notepad-plus-plus/issues/6095 "Marked text needs to be copyable"
https://github.com/notepad-plus-plus/notepad-plus-plus/issues/8943 "Add "Marked Style N text to Clipboard" menu commands"
