### PR TITLE
add -settingsDir documentation for v7.9.2

### DIFF
--- a/content/docs/command-prompt.md
+++ b/content/docs/command-prompt.md
@@ -10,14 +10,15 @@ to control its startup and affect its behavior.
 ## Help usage
 
 ```
-notepad++ [--help] [-multiInst] [-noPlugin] [-l<lang>] [-n<line>] [-c<column>]
-  [-p<pos>] [-x<left-pos>] [-y<TopPos>] [-nosession] [-notabbar] [-ro]
-  [-systemtray] [-loadingTime] [-alwaysOnTop] [-openSession] [-openFoldersAsWorkspace] [-r]
+notepad++ [--help] [-multiInst] [-noPlugin] [-l<Language>] [-L<langCode]
+  [-n<line>] [-c<column>] [-p<pos>] [-x<left-pos>] [-y<TopPos>]
+  [-nosession] [-notabbar] [-ro] [-systemtray] [-loadingTime]
+  [-alwaysOnTop] [-openSession] [-r]
   [-qn<EasterEggName> | -qt<Text> | -qf<ContentFileName>]
   [-qSpeed(1|2|3)] [-quickPrint]
+  [-settingsDir="d:\your settings dir\"] [-openFoldersAsWorkspace]
   [filepath]
 ```
-
 
 * `--help`: The help message for command line arguments. It will be shown before
   Notepad++'s launch.
@@ -32,6 +33,7 @@ notepad++ [--help] [-multiInst] [-noPlugin] [-l<lang>] [-n<line>] [-c<column>]
   `actionscript`, `nsis`, `tcl`, `lisp`, `scheme`, `asm`, `diff`, `props`,
   `postscript`, `ruby`, `smalltalk`, `vhdl`, `kix`, `autoit`, `Gui4Cli`,
   `powershell`, `caml`, `ada`, `verilog`, `matlab`, `haskell`, `inno`, `cmake`, `yaml`, `r` and `jsp`.
+* `-L`: Apply indicated localization, *langCode* is browser language code
 * `-n`: Scroll to indicated line (*LineNumber*) on `filepath`.
 * `-c`: Scroll to indicated column (*ColumnNumber*) on `filepath`.
 * `-p`: Scroll to indicated 0 base position (*Position*) on `filepath`.
@@ -44,14 +46,14 @@ notepad++ [--help] [-multiInst] [-noPlugin] [-l<lang>] [-n<line>] [-c<column>]
 * `-loadingTime`: Display Notepad++ loading time.
 * `-alwaysOnTop`: Make Notepad++ always on top.
 * `-openSession`: Open a session. `filepath` must be a session file.
-* `-openFoldersAsWorkspace`: Any folders listed as arguments will be opened as a workspace, rather than opening all the contained files individually (new to v7.8)
-* `-r`: Open files recursively. This argument will be ignored if
-  `filepath` contain no wildcard character.
+* `-r`: Open files recursively. This argument will be ignored if `filepath` contain no wildcard character.
 * `-qn`: Launch ghost typing to display easter egg via its *EasterEggName*.
 * `-qt`: Launch ghost typing to display a text via the given *Text*
 * `-qf`: Launch ghost typing to display a file content via the file path *ContentFileName*
 * `-qSpeed`: Ghost typing speed. Value from 1 to 3 for slow, fast and fastest
 * `-quickPrint`: Print the file given as argument `filepath` then quit Notepad++
+* `settingsDir="d:\your settings dir\"`: Override the default settings dir
+* `-openFoldersAsWorkspace`: Any folders listed as arguments will be opened as a workspace, rather than opening all the contained files individually (new to v7.8)
 * `filepath`: file or folder name to open (absolute or relative path name)
 
 

--- a/content/docs/command-prompt.md
+++ b/content/docs/command-prompt.md
@@ -52,7 +52,7 @@ notepad++ [--help] [-multiInst] [-noPlugin] [-l<Language>] [-L<langCode]
 * `-qf`: Launch ghost typing to display a file content via the file path *ContentFileName*
 * `-qSpeed`: Ghost typing speed. Value from 1 to 3 for slow, fast and fastest
 * `-quickPrint`: Print the file given as argument `filepath` then quit Notepad++
-* `settingsDir="d:\your settings dir\"`: Override the default settings dir
+* `settingsDir="d:\your settings dir\"`: Override the default settings dir (new to v7.9.2)
 * `-openFoldersAsWorkspace`: Any folders listed as arguments will be opened as a workspace, rather than opening all the contained files individually (new to v7.8)
 * `filepath`: file or folder name to open (absolute or relative path name)
 

--- a/content/docs/config-files.md
+++ b/content/docs/config-files.md
@@ -21,7 +21,7 @@ In a portable installation, the configuration files go in the same directory as 
 If you enable the [Cloud settings](../preferences/#cloud), some configuration files will go in the defined directory (including `session.xml`, `contextMenu.xml`, `shortcuts.xml`, `userDefineLang.xml`, `langs.xml`, `stylers.xml`, and `config.xml`;
 the `userDefineLang\` subfolder can be placed there as well, though it won't be created by default when the Cloud settings folder is first populated).
 
-There is a [command-line option](../command-prompt/) `-settingsDir` which will set a new directory for the configuration file location (added in v7.9.x _**!!TDB!!!**_)
+There is a [command-line option](../command-prompt/) `-settingsDir` which will set a new directory for the configuration file location (added in v7.9.2).
 
 If the `--settingsDir` option is set, that configuration file directory will take priority over any other configuration file directory. If the Cloud directory setting is defined and enabled, that will take priority over the portable or standard configuration file directory. If `doLocalConf.xml` is present, the portable configuration file location will take priority over the `%AppData%\Notepad++\` directory.  If none of the other configuration file directories are active, then the standard configuration file directory is `%AppData%\Notepad++\`.
 

--- a/content/docs/config-files.md
+++ b/content/docs/config-files.md
@@ -21,7 +21,9 @@ In a portable installation, the configuration files go in the same directory as 
 If you enable the [Cloud settings](../preferences/#cloud), some configuration files will go in the defined directory (including `session.xml`, `contextMenu.xml`, `shortcuts.xml`, `userDefineLang.xml`, `langs.xml`, `stylers.xml`, and `config.xml`;
 the `userDefineLang\` subfolder can be placed there as well, though it won't be created by default when the Cloud settings folder is first populated).
 
-If the Cloud directory is enabled, that will take priority over the portable or standard config file location; if `doLocalConf.xml` is present, it will take priority over the `%AppData%\Notepad++\` folder; if neither are active, then the standard config file location is `%AppData%\Notepad++\`.
+There is a [command-line option](../command-prompt/) `-settingsDir` which will set a new directory for the configuration file location (added in v7.9.x _**!!TDB!!!**_)
+
+If the `--settingsDir` option is set, that configuration file directory will take priority over any other configuration file directory. If the Cloud directory setting is defined and enabled, that will take priority over the portable or standard configuration file directory. If `doLocalConf.xml` is present, the portable configuration file location will take priority over the `%AppData%\Notepad++\` directory.  If none of the other configuration file directories are active, then the standard configuration file directory is `%AppData%\Notepad++\`.
 
 ## Editing Configuration Files
 


### PR DESCRIPTION
update command-prompt.md for describing the option syntax, and config-files.md for describing the priority of that option vs cloud, portable, and normal/appdata.