### PR TITLE
Add installer command-line options

### DIFF
--- a/content/docs/command-prompt.md
+++ b/content/docs/command-prompt.md
@@ -90,7 +90,7 @@ usage list.  These are intended for advanced usage or other special circumstance
 
 ## Installer Options
 
-The installer application accepts the [three NSIS command-line options](https://nsis.sourceforge.io/Which_command_line_parameters_can_be_used_to_configure_installers):
+The Notepad++ [installer executable](../getting-started/#installer) accepts the [three NSIS command-line options](https://nsis.sourceforge.io/Which_command_line_parameters_can_be_used_to_configure_installers):
 * `/S` : silent installation
 * `/D=c:\blah` or `/D=c:\path with spaces\blah` : overrides the default installation directory.  Must be the last argument on the installer command line.  Do _not_ put quotes around the path, even when there are spaces.
 * `/NCRC`: skips the installer's CRC check

--- a/content/docs/command-prompt.md
+++ b/content/docs/command-prompt.md
@@ -68,7 +68,7 @@ as you should always quote the filename.
 This help usage list can be accessed inside Notepad++ using the `--help` command
 line argument, or using the **?**-menu's **Command Line Arguments** entry.
 
-## Additional Options
+### Additional Options
 
 There are other Notepad++ command-line options which aren't included in the help
 usage list.  These are intended for advanced usage or other special circumstances.
@@ -87,3 +87,10 @@ usage list.  These are intended for advanced usage or other special circumstance
   [this Notepad++ Community Forum post](https://community.notepad-plus-plus.org/post/52805),
   where a script run using the PythonScript plugin is able to use a command-line option
   to affect the script's behavior.
+
+## Installer Options
+
+The installer application accepts the [three NSIS command-line options](https://nsis.sourceforge.io/Which_command_line_parameters_can_be_used_to_configure_installers):
+* `/S` : silent installation
+* `/D=c:\blah` or `/D=c:\path with spaces\blah` : overrides the default installation directory.  Must be the last argument on the installer command line.  Do _not_ put quotes around the path, even when there are spaces.
+* `/NCRC`: skips the installer's CRC check

--- a/content/docs/command-prompt.md
+++ b/content/docs/command-prompt.md
@@ -92,5 +92,7 @@ usage list.  These are intended for advanced usage or other special circumstance
 
 The Notepad++ [installer executable](../getting-started/#installer) accepts the [three NSIS command-line options](https://nsis.sourceforge.io/Which_command_line_parameters_can_be_used_to_configure_installers):
 * `/S` : silent installation
-* `/D=c:\blah` or `/D=c:\path with spaces\blah` : overrides the default installation directory.  Must be the last argument on the installer command line.  Do _not_ put quotes around the path, even when there are spaces.
 * `/NCRC`: skips the installer's CRC check
+* `/D=c:\blah` or `/D=c:\path with spaces\blah` : overrides the default installation directory.  
+    * Do _not_ put quotes around the path, even when there are spaces.
+    * Because it allows spaces in the path, this option **must** be the last argument on the installer command line, if included.

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -20,6 +20,8 @@ Choose 32 or 64 bit Notepad++ build according to your operating system, then cho
 1. Download the installer
 2. Run the executable binary and follow the installation flow
 
+If you are doing managed installation or otherwise want to control the installer from the command line, the installer has its own [command line options](../command-prompt/#installer-options).
+
 ## Install Notepad++ from 7z or zip
 1. Create a new folder
 2. Unzip the content into the new folder

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -20,7 +20,7 @@ Choose 32 or 64 bit Notepad++ build according to your operating system, then cho
 1. Download the installer
 2. Run the executable binary and follow the installation flow
 
-If you are doing managed installation or otherwise want to control the installer from the command line, the installer has its own [command line options](../command-prompt/#installer-options).
+If you are doing managed installation or otherwise want to control the installer from the command line, the installer has a few [command line options](../command-prompt/#installer-options).
 
 ## Install Notepad++ from 7z or zip
 1. Create a new folder


### PR DESCRIPTION
closes #164 

Add sections to both the Getting Started page and the Command Prompt page -- the details went in the Command Prompt page, and the Getting Started # Installer links to those details.