### PR TITLE
Clarify Function List config files

### DIFF
--- a/content/docs/config-files.md
+++ b/content/docs/config-files.md
@@ -229,6 +229,8 @@ If 2 above lines are in *overrideMap.xml*, function list will load your parsers 
 ```
 Here you define a parser rule file name for your KRL UDL. While you open a file which is recognized as KRL file, then function list engin will load `functionList\krl.xml` to show the KRL function list. If you have no KRL UDL defined in your Notepad++, you have to define a dummy one (with the name "KRL") to make it work.
 
+The `functionList\`_languagename_`.xml` parser file itself, whether it's for a builtin language or a UDL-based language, requires the structure `<NotepadPlus><functionList><parser...>...</parser></functionList></NotepadPlus>`, where the attributes and contents of the `<parser>` are described in the documents section about [How to Customize Function List](../function-list/#how-to-customize-function-list).  You can look at any of the [default parser files](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/functionList/) for examples of working Function List configurations.
+
 ### v7.9 and previous versions
 
 The `functionList.xml` config file contains XML entries for each language's function list definition, as well as a map that tells Notepad++ which section of the XML is applied to each file type.
@@ -273,7 +275,7 @@ If you previously had a v7.9-or-earlier style function list entry in `functionLi
 4. Open the `functionList\blah.xml` for your particular language
    * If you don't have `blah.xml` yet, copy one of the v7.9.1-or-newer language's XML files to `blah.xml`, and remove the whole `<parser...> ... </parser>` section
 5. Copy the `<parer...>...</parser>` section from the old `functionList.xml` to the `functionList\blah.xml`
-   * Please note that the `blah.xml` should _not_ contain a `<parsers>` section, _just_ the `<parser>` section.  It will cause problems with the Function List if you wrap it in the `<parsers>...</parsers>` block.
+   * Please note that the `blah.xml` should _not_ contain a `<parsers>` section, _just_ the `<parser>` section.  It will cause problems with the Function List if you wrap it in the `<parsers>...</parsers>` block.  Make sure it ends up with the v7.9.1-or-newer structure described above.
 
 ## Other Configuration Files
 

--- a/content/docs/config-files.md
+++ b/content/docs/config-files.md
@@ -263,6 +263,18 @@ If you want to add **Function List** capability for your User Defined Language (
 
     where the `fn_udl_example` must match the `<association id>`.  The `displayName` sets what shows in the **Function List** window header.  The `...Expr` values are all defined in [regular expression syntax](../searching/#regular-expressions).
 
+### Upgrading old Function List entries
+
+If you previously had a v7.9-or-earlier style function list entry in `functionList.xml`, and you want to use it in a v7.9.1-or-later Notepad++, you can extract the pieces to the right locations in the new mulit-file format:
+
+1. Open the old `functionList.xml`.
+2. Open the `functionList\overrideMap.xml`
+3. Copy the `<association...>` tag from the old `functionList.xml` to the `functionList\overrideMap.xml`, and place near the end of the `<associationMap>` section.  Make sure it follows the rules for v7.9.1-or-later `<association>` tag syntax
+4. Open the `functionList\blah.xml` for your particular language
+   * If you don't have `blah.xml` yet, copy one of the v7.9.1-or-newer language's XML files to `blah.xml`, and remove the whole `<parser...> ... </parser>` section
+5. Copy the `<parer...>...</parser>` section from the old `functionList.xml` to the `functionList\blah.xml`
+   * Please note that the `blah.xml` should _not_ contain a `<parsers>` section, _just_ the `<parser>` section.  It will cause problems with the Function List if you wrap it in the `<parsers>...</parsers>` block.
+
 ## Other Configuration Files
 
 * `autoCompletion\*.xml`: files for defining per-language [auto-completion](../auto-completion/#auto-completion-file-format).


### PR DESCRIPTION
closes #160 

* Adds a description of the XML structure for the v7.9.1-and-newer config file (to make it clear that `<parsers>` is no longer required)
* Adds a section for how to convert a v7.9-or-earlier entry into the v7.9.1-and-newer entry.
