### PR TITLE
Github CI action update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+ # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -19,12 +19,14 @@ jobs:
       working-directory: .
       run: |
            cmd /c start hugo.exe server --minify --theme book
-           $env:Path += ";C:\Program Files\WinHTTrack\" 
-           httrack.exe "http://127.0.0.1:1313/" -O "./nppUserManual" "+*.npp-user-manual.org/*" -v
+           $env:Path += ";C:\Program Files\WinHTTrack\"
+           httrack.exe "http://127.0.0.1:1313/" -O "./httrack_output" "+*.npp-user-manual.org/*" "+*.127.0.0.1:1313/*"  "+localhost:1313/*"  "+localhost:1313" -v
+           Set-Location -Path httrack_output
+           Rename-Item -Path 127.0.0.1_1313 -NewName nppUserManual
 
     - name: Archive artifacts for hugo
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
-          name: N++ static page
-          path: ./nppUserManual/
+          name: nppUserManual
+          path: ./httrack_output/nppUserManual/
 


### PR DESCRIPTION
- added dependabot.yml action to check for updated github actions on a weekly base
- adapted CI_build.yml to use similar build steps as one used for tag action