### PR TITLE
Add link to nppUserManual.zip asset from main page

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -11,12 +11,20 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v2
 
-    - name: Install hugo extended via chocolatey
+    - name: Install hugo extended and httrack via chocolatey
       working-directory: .
-      run: choco install hugo-extended
+      run: choco install hugo-extended httrack
 
-    - name: Build docu
+    - name: Retrieve data from server
       working-directory: .
-      run: hugo.exe --minify --theme book
+      run: |
+           cmd /c start hugo.exe server --minify --theme book
+           $env:Path += ";C:\Program Files\WinHTTrack\" 
+           httrack.exe "http://127.0.0.1:1313/" -O "./nppUserManual" "+*.npp-user-manual.org/*" -v
 
+    - name: Archive artifacts for hugo
+      uses: actions/upload-artifact@v1
+      with:
+          name: N++ static page
+          path: ./nppUserManual/
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -12,16 +12,6 @@ Of course, it's not our goal to create bad documentation, but you get what we me
 
 **Notepad++ User Manual** is built collaboratively, and [your contribution is very welcome](https://github.com/notepad-plus-plus/npp-usermanual).
 
-<center>
-    <a href="https://github.com/notepad-plus-plus/npp-usermanual/releases/latest/download/nppUserManual.zip" style="
-        text-align: center;
-        font-size: larger;
-        -moz-border-radius: 1em;
-        border-radius: 1em;
-        border: 1px solid #00A2E8;
-        background-color: white;
-        color: #00A2E8;
-        padding: 2px 1em;
-    ">Download most recent offline User Manual</a>
-</center>
+### Offline Manual
 
+You may [download a zipfile of the nppUserManual](https://github.com/notepad-plus-plus/npp-usermanual/releases/latest/download/nppUserManual.zip) to use as an offline reference.

--- a/content/_index.md
+++ b/content/_index.md
@@ -24,3 +24,4 @@ Of course, it's not our goal to create bad documentation, but you get what we me
         padding: 2px 1em;
     ">Download most recent offline User Manual</a>
 </center>
+


### PR DESCRIPTION
Apparently, my link wasn't in the branch that I did my last PR on, so I am adding it here.

When I was trying out my original fancy formatting for the link that I used during experiments, it would render in hugo's live server, but not in the httrack extraction.  So I settled on a simple markdown link, more in keeping with the rest of the document.  This link makes it all the way into the httrack extraction in the artifact (thanks @chcg for recommending we keep the CI element of the actions -- it was obviously the right choice), and everything looks good to me.