### PR TITLE
Dark mode icons

### DIFF
--- a/content/docs/preferences.md
+++ b/content/docs/preferences.md
@@ -73,12 +73,12 @@ The Dark Mode feature (added in v8.0.0) is controlled here.
       * it will change the active theme to `DarkModeDefault`
         * _Reminder_: changing the theme does _not_ change your UDL colors, as discussed in the [UDL and Themes](../user-defined-language-system/#udl-and-themes) section.  If your UDL was colored to match some other theme, the colors will likely mismatch, and you will need to edit the UDL colors to make it match the DarkModeDefault theme.
       * it will change the coloring of the menu bar and toolbar (if visible)
-        * _Note_: You must exit Notepad++ completely and restart in order to get the rest of the UI (like the top title bar) to be fully in Dark Mode.
+        * _Note_: You must exit Notepad++ completely and restart in order to get the rest of the UI (like the top title bar) to be fully in Dark Mode
       * it may change your [General > Toolbar](#General) settings to use one of the **Fluent UI** icon sets: if you already had a Fluent icon set selected, it will keep it; if you had the **Standard icons: small** selected, it will change to **Fluent UI: small** icons
       * When you run in Dark Mode, the saved-file icon will not show up on your Tab Bar, whether or not you have [Alternate Icons](#General "General > Tab Bar > Alternate Icons") checked.  However, a read-only file or an edited file will still show their icons (either different colored disks, or the lock icon and pencil icon, depending on Alternate Icons setting).
     * When you uncheck this checkbox (☐):
-      * it will change the active theme to `Default (stylers.xml)`.
-        * _Note_: this is true even if you previously had a different theme selected before trying out Dark Mode.  If you would like a different theme, you will have to manually change to that theme
+      * it will change the active theme to `Default (stylers.xml)`
+        * _Note_: this is true even if you previously had a different theme selected before trying out Dark Mode.  If you would like a different theme, you will have to manually change to that theme.
       * it will change the coloring of the menu bar and toolbar (if visible)
         * _Note_: You must exit Notepad++ completely and restart in order to get the rest of the UI (like the top title bar) to be fully out of Dark Mode.
       * it will leave your [Toolbar](#General) settings with the same icon set as you had when you were in Dark Mode

--- a/content/docs/preferences.md
+++ b/content/docs/preferences.md
@@ -37,7 +37,7 @@ These affect the user interface (localization, toolbar, tab bar, and more).
     * `☐ Vertical`: have the tabs on their side on the left, rather than along the top
     * `☐ Reduce`: make the tab bar vertical region and font size smaller
     * `☐ Alternate icons`: change the "saved"/"edited"/"read-only" icons from blue/red/grey disk-icons to checkmark/pencil/lock symbols, respectively
-      * The alternate icons option is designed to improve the user experience for visually-impaired users, and any who prefer differnt symbols rather than different colors to distinguish the status of each file. 
+      * The alternate icons option is designed to improve the user experience for visually-impaired users, and any who prefer different symbols rather than different colors to distinguish the status of each file. 
       * _Note_: In [Dark Mode](#dark-mode), the "saved" symbol (either the blue disk or the green checkmark) will _not_ be shown; the "edited" and "read-only" icons will be.
     * `☐ Lock (no drag and drop)`: prevent the reordering of tabs by drag-and-drop on the tab bar (unselected, drag-and-drop on the tab bar will reorder tabs)
     * `☐ Darken inactive tags`: change the fill-colour on inactive tabs to a darker colour

--- a/content/docs/preferences.md
+++ b/content/docs/preferences.md
@@ -36,7 +36,9 @@ These affect the user interface (localization, toolbar, tab bar, and more).
     * `☐ Multi-line`: if there are enough tabs, they will wrap to a second line
     * `☐ Vertical`: have the tabs on their side on the left, rather than along the top
     * `☐ Reduce`: make the tab bar vertical region and font size smaller
-    * `☐ Alternate icons`: change the saved/edited/read-only icons from blue/red/grey disk-icons to checkmark/pencil/lock symbols, respectively; the alternate icons option is designed to improve the user experience for visually-impaired users
+    * `☐ Alternate icons`: change the "saved"/"edited"/"read-only" icons from blue/red/grey disk-icons to checkmark/pencil/lock symbols, respectively
+      * The alternate icons option is designed to improve the user experience for visually-impaired users, and any who prefer differnt symbols rather than different colors to distinguish the status of each file. 
+      * _Note_: In [Dark Mode](#dark-mode), the "saved" symbol (either the blue disk or the green checkmark) will _not_ be shown; the "edited" and "read-only" icons will be.
     * `☐ Lock (no drag and drop)`: prevent the reordering of tabs by drag-and-drop on the tab bar (unselected, drag-and-drop on the tab bar will reorder tabs)
     * `☐ Darken inactive tags`: change the fill-colour on inactive tabs to a darker colour
     * `☐ Draw a coloured bar on active tab`: indicate the active tab by adding a coloured bar
@@ -66,7 +68,20 @@ These influence editing (carets, code-folding, line wrapping, and more).
 
 The Dark Mode feature (added in v8.0.0) is controlled here.
 
-* `☐ Enable Dark Mode`: enables Dark Mode, where the UI is set to dark background with light text
+* `☐ Enable Dark Mode`: enables Dark Mode, where the UI is set to dark background with light text  
+    * When you check this checkbox (☑):
+      * it will change the active theme to `DarkModeDefault`
+        * _Reminder_: changing the theme does _not_ change your UDL colors, as discussed in the [UDL and Themes](../user-defined-language-system/#udl-and-themes) section.  If your UDL was colored to match some other theme, the colors will likely mismatch, and you will need to edit the UDL colors to make it match the DarkModeDefault theme.
+      * it will change the coloring of the menu bar and toolbar (if visible)
+        * _Note_: You must exit Notepad++ completely and restart in order to get the rest of the UI (like the top title bar) to be fully in Dark Mode.
+      * it may change your [General > Toolbar](#General) settings to use one of the **Fluent UI** icon sets: if you already had a Fluent icon set selected, it will keep it; if you had the **Standard icons: small** selected, it will change to **Fluent UI: small** icons
+      * When you run in Dark Mode, the saved-file icon will not show up on your Tab Bar, whether or not you have [Alternate Icons](#General "General > Tab Bar > Alternate Icons") checked.  However, a read-only file or an edited file will still show their icons (either different colored disks, or the lock icon and pencil icon, depending on Alternate Icons setting).
+    * When you uncheck this checkbox (☐):
+      * it will change the active theme to `Default (stylers.xml)`.
+        * _Note_: this is true even if you previously had a different theme selected before trying out Dark Mode.  If you would like a different theme, you will have to manually change to that theme
+      * it will change the coloring of the menu bar and toolbar (if visible)
+        * _Note_: You must exit Notepad++ completely and restart in order to get the rest of the UI (like the top title bar) to be fully out of Dark Mode.
+      * it will leave your [Toolbar](#General) settings with the same icon set as you had when you were in Dark Mode
 
 ### Margins / Border / Edge
 


### PR DESCRIPTION
* mention what happens to the theme, UI colors, and toolbar icons
* emphasize that the "saved" tabbar icon will not be used in Dark Mode in both the Dark Mode and General > Tab Bar sections

prompted by notepad-plus-plus/notepad-plus-plus#10159 and closes #260