### PR TITLE
clarify scope of Highlighting > Mark All settings

### DIFF
--- a/content/docs/preferences.md
+++ b/content/docs/preferences.md
@@ -207,6 +207,7 @@ Affects highlighting of selected text.
 * **Mark All** (v8.0.0 and later)
     * `☐ Match case`: Mark All will be case-sensitive
     * `☐ Match whole word only`: Mark All will require a whole "word" (sequence of "word characters", as defined in the **Delimiter** preferences)
+    * This setting section applies to the **Search** menu's **Mark All** submenu entries, and the equivalent [right-click Context Menu](../config-files/#the-context-menu-contextmenu-xml)'s **Style all occurrences of token** submenu entries.
 * **Smart Highlighting**
     * `☐ Enable`: if you select a piece of text, Smart Highlighting will color all matching pieces of text.  It will use the style defined in **Style Configurator > Global Styles > Smart Highlighting**
     * `☐ Highlight another view`: Smart Highlighting will also apply to the other "view" (when you have documents open in both of Notepad++ view panes)

--- a/content/docs/preferences.md
+++ b/content/docs/preferences.md
@@ -207,7 +207,7 @@ Affects highlighting of selected text.
 * **Mark All** (v8.0.0 and later)
     * `☐ Match case`: Mark All will be case-sensitive
     * `☐ Match whole word only`: Mark All will require a whole "word" (sequence of "word characters", as defined in the **Delimiter** preferences)
-    * This setting section applies to the **Search** menu's **Mark All** submenu entries, and the equivalent [right-click Context Menu](../config-files/#the-context-menu-contextmenu-xml)'s **Style all occurrences of token** submenu entries.
+    * This setting section applies to the **Search** menu's **Mark All** submenu entries, and the equivalent [right-click Context Menu](../config-files/#the-context-menu-contextmenu-xml)'s **Style all occurrences of token** submenu entries, for applying "Style Tokens" to specific text.
 * **Smart Highlighting**
     * `☐ Enable`: if you select a piece of text, Smart Highlighting will color all matching pieces of text.  It will use the style defined in **Style Configurator > Global Styles > Smart Highlighting**
     * `☐ Highlight another view`: Smart Highlighting will also apply to the other "view" (when you have documents open in both of Notepad++ view panes)


### PR DESCRIPTION
it wasn't clear to all readers that the "Highlighting > Mark All** settings checkboxes applied to the "style tokens" (which is the old <v8 context-menu naming for that feature, and thus how many users think of that feature)