### PR TITLE
v8.1.3 documentation changes

### DIFF
--- a/content/docs/plugin-communication.md
+++ b/content/docs/plugin-communication.md
@@ -361,8 +361,8 @@ name should be the same value as previously used to register the dialog.*
 
 ---
 
-#### **NPPM_DOCSWITCHERDISABLECOLUMN**
-*Sets the extension column in doc switcher window.
+#### **NPPM_DOCLISTDISABLECOLUMN** 
+*Sets the extension column in Document List panel.  (Known as **NPPM_DOCSWITCHERDISABLECOLUMN** in v8.1.2 and earlier)
 If disableOrNot is True, extension column is hidden otherwise it is visible.*
 
 **Parameters**:
@@ -1267,8 +1267,8 @@ struct ShortcutKey {
 
 ---
 
-#### **NPPM_ISDOCSWITCHERSHOWN**
-*Checks the visibility of the document switcher window.*
+#### **NPPM_ISDOCLISTSHOWN**
+*Checks the visibility of the Document List panel. (Known as **NPPM_ISDOCSWITCHERSHOWN** before v8.1.3.)*
 
 **Parameters**:
 
@@ -1279,7 +1279,7 @@ struct ShortcutKey {
 : int, must be zero.
 
 **Return value**:
-: Returns True if the document switcher is currently shown, False otherwise
+: Returns True if the Document List panel is currently shown, False otherwise
 
 ---
 
@@ -1771,6 +1771,23 @@ STATUSBAR_TYPING_MODE   5
 
 **Return value**:
 : Returns 0 on failure, nonzero on success
+
+---
+
+#### **NPPM_SHOWDOCLIST** 
+*Show or hide the Document List panel (Known as **NPPM_SHOWDOCSWITCHER=** in v8.1.2 and earlier).
+If toShowOrNot is True, the Document List panel is shown otherwise it is hidden.*
+
+**Parameters**:
+
+*wParam [in]*
+: int, must be zero.
+
+*lParam [in]*
+: BOOL toShowOrNot
+
+**Return value**:
+: Returns True
 
 ---
 

--- a/content/docs/plugin-communication.md
+++ b/content/docs/plugin-communication.md
@@ -362,8 +362,10 @@ name should be the same value as previously used to register the dialog.*
 ---
 
 #### **NPPM_DOCLISTDISABLECOLUMN** 
-*Sets the extension column in Document List panel.  (Known as **NPPM_DOCSWITCHERDISABLECOLUMN** in v8.1.2 and earlier)
+*Sets the extension column in Document List panel.
 If disableOrNot is True, extension column is hidden otherwise it is visible.*
+
+*Known as `NPPM_DOCSWITCHERDISABLECOLUMN` in v8.1.2 and earlier.*
 
 **Parameters**:
 
@@ -1268,7 +1270,9 @@ struct ShortcutKey {
 ---
 
 #### **NPPM_ISDOCLISTSHOWN**
-*Checks the visibility of the Document List panel. (Known as **NPPM_ISDOCSWITCHERSHOWN** before v8.1.3.)*
+*Checks the visibility of the Document List panel.*
+
+*Known as `NPPM_ISDOCSWITCHERSHOWN` in v8.1.2 and earlier.*
 
 **Parameters**:
 
@@ -1775,8 +1779,10 @@ STATUSBAR_TYPING_MODE   5
 ---
 
 #### **NPPM_SHOWDOCLIST** 
-*Show or hide the Document List panel (Known as **NPPM_SHOWDOCSWITCHER=** in v8.1.2 and earlier).
+*Show or hide the Document List panel.
 If toShowOrNot is True, the Document List panel is shown otherwise it is hidden.*
+
+*Known as `NPPM_SHOWDOCSWITCHER` in v8.1.2 and earlier.*
 
 **Parameters**:
 

--- a/content/docs/preferences.md
+++ b/content/docs/preferences.md
@@ -29,8 +29,8 @@ These affect the user interface (localization, toolbar, tab bar, and more).
         * `Filled Fluent UI: large`: uses large versions of the Fluent UI icons, in a filled (or reverse-video) style
         * `Standard icons: small`: these are the small version of the traditional (pre-v8.0.0) icons
 * **Document List Panel**:
-    * `☐ Show`: will show the Doc Switcher panel, which can be used to quickly switch between documents
-    * `☐ Disable extension column`: If enabled, the Doc Switcher panel will _not_ have the second column showing extensions (instead, the extension will be part of the Name column)
+    * `☐ Disable extension column`: If enabled, the [Document List](../views/#panels) panel will _not_ have the second column showing extensions (instead, the extension will be part of the Name column)
+    * prior to v8.1.3, the `☐ Show` setting would toggle the Document List panel, but that is now controlled by the [View menu's "Document List" entry](../views/#panels)
 * **Tab Bar**:
     * `☐ Hide`: the tab bar for the open files will not be visible
     * `☐ Multi-line`: if there are enough tabs, they will wrap to a second line
@@ -83,18 +83,19 @@ The Dark Mode feature (added in v8.0.0) is controlled here.
         * _Note_: You must exit Notepad++ completely and restart in order to get the rest of the UI (like the top title bar) to be fully out of Dark Mode.
       * it will leave your [Toolbar](#General) settings with the same icon set as you had when you were in Dark Mode
 * Tones: allow you to change the tone of the Dark Mode (new to v8.1.2)
+   * _Note_: Dark Mode Tones affect most of the user interface, including main menus and toolbars and most of the dialogs, as of v8.1.3. (In v8.1.2, the Tones affected the menus and the Find/Replace/Mark dialog, but not the other dialogs.)  The menu pull-downs, as well as Windows-defined dialog boxes like **Open** and **Save**, have their colors defined by operating system settings, and Notepad++ Dark Mode settings _will not_ affect them.
    * `☐ Black tone`, `☐ Black tone`, `☐ Black tone`, `☐ Black tone`, `☐ Black tone`, `☐ Black tone`, `☐ Black tone` => The dark color has a hint of that colored tone
    * `☐ Customized tone` => allows you to configure the tones of the individual components of the Dark Mode (even to the point of not being Dark anymore):
      * `Top` => choose the color of the menu bar and tool bar
      * `Menu hot track` => choose the color of the active menu bar entry
      * `Active` => choose the color of the active tab on the tab bar
-     * `Main` => choose the color of the inactive tab(s) on the tab bar, as well as background colors for the Find/Replace/Mark dialog
+     * `Main` => choose the color of the inactive tab(s) on the tab bar, as well as background colors for most dialog boxes
      * `Error` => choose the color for the error indicator on the Incremental Search bar
-     * `Text` => choose the color for the menu bar entry names, and other normal text in the Find/Replace/Mark dialog
-     * `Darker text` => choose the color for the darker text in the Find/Replace/Mark dialog
-     * `Disabled text` => choose the color for disabled items in the Find/Replace/Mark dialog (often referred to as "greyed out" or "disabled")
+     * `Text` => choose the color for the menu bar entry names, and other normal text for most dialog boxes
+     * `Darker text` => choose the color for the darker text for most dialog boxes
+     * `Disabled text` => choose the color for disabled items in most dialog boxes (often referred to as "greyed out" or "disabled")
      * `Edge` => choose the color for the veritcal separator bars on tab bars (in the main window and in dialogs), and other edges (like the boxes around color selectors)
-   * _Note_: Dark Mode Tones currently affect the main user interface, and the Find/Replace/Mark dialog. Other dialogs, and the menu pull-downs, have their colors defined by operating system settings.
+     * `Link` => choose the color for link text in dialog boxes (for example the hyperlink URL in the User Defined Languages dialog) (new to v8.1.3)
 
 ### Margins / Border / Edge
 

--- a/content/docs/views.md
+++ b/content/docs/views.md
@@ -63,9 +63,15 @@ The **Word wrap**[↗](#remembered-settings "Remembered Setting") entry will tog
 
 When this toggle is not set, you will have to use the horizontal scroll bar to the see the whole current line; when the toggle is set, the line will _appear_ to wrap at the end of your current editor view width, but there will be no newline (so if you open the same text file in a different editor, or a different computer's Notepad++ with different settings, it won't wrap at that character).  **Note**: The line wraps on whole-word increments when possible, but if the current word is longer than the entire line-length, it _will_ wrap in the middle of the word.
 
-## Hiding and Folding
+## Focus View
+
+The **Focus on Another View** action will swap your active focus between the two Views (if both Views are visible).
+
+## Hiding Lines
 
 The **Hide Lines** action will hide the active line or selected lines, and place symbols in the margin to allow you to unhide those lines.  The text is still there when you save, it will just temporarily not be visible while you are editing (until you unhide the text, or re-start Notepad++).
+
+## Folding
 
 There are a group of folding-related commands, which will allow the folding or unfolding of blocks of text based on the current syntax highlighter lexer for a [programming language](../programing-languages/) or [User Defined Langauge](../user-defined-language-system/), and the folding rules defined in that lexer or UDL.  (To "fold" the text means to temporarily hide a block of text; to "unfold" the text means to reveal that block of text again.)  If folding blocks are nested (contained inside other folding blocks), the outermost block is level 1, the block immediately inside that is level 2, and so on.  (Folding is _not_ remembered from one run to the next, nor is it saved in the automatic or manually-saved session file.)
 
@@ -86,6 +92,8 @@ The **Project Panels**[↗](#remembered-settings "Remembered Setting") sub-menu 
 The **Folder as Workspace**[↗](#remembered-settings "Remembered Setting") entry will toggle the display of the [Folder as Workspace](../session/#folder-as-workspace) panel
 
 The **Document Map**[↗](#remembered-settings "Remembered Setting") item will toggle the display of the Document Map panel, which shows a copy of the file in a tiny font, with a highlighted range to indicate which section of the current file is visible in the editor.
+
+The **Document List**[↗](#remembered-settings "Remembered Setting") toggle will display the Document List panel, which lists all the open documents and allows easily switching between them.  (Prior to v8.1.3, the panel was known as the **Doc Switcher** panel and controlled through the [General preferences](../preferences/#general), but that name was confused with the Document Switcher `Ctrl+TAB` settings in [MISC preferences](../preferences/#misc).)
 
 The **Function List**[↗](#remembered-settings "Remembered Setting") toggle will display the [Function List](../function-list/) panel, which lists the functions, methods, and classes in the current file, and allows easy navigation to those sections of the file by double-clicking in the Function List panel.  (The "functions, methods, and classes" are programming terms, but the feature can also be used for listing headings or sections of other structured files, or through [config files](config-files/#function-list), can be made to match anything else that you choose to match for indicating "sections" of your text, whatever that happens to mean to you.)
 


### PR DESCRIPTION
Updated
* Views: the new Document List entry (closes #268)
* Preferencs: the General>Document List settings  and Dark Mode settings (closes #269)
* Plugin Communication: update the message names for "Document List" instead of "Doc Switcher" (closes #270)