### PR TITLE
Config Files write after exit

### DIFF
--- a/content/docs/config-files.md
+++ b/content/docs/config-files.md
@@ -12,6 +12,8 @@ Notepad++ offers a comprehensive user interface to review or change most of its 
 * Editing previously-recorded macros, or crafting new macros manually
 * Adding keywords to a language, because the new language version isn't matched yet
 
+Please note that Notepad++ writes the configuration files when it exits, which is why the [Editing Configuration Files](#editing-configuration-files) section below says that Notepad++ may overwrite your changes.  But this also means that, when you make a change using Notepad++ menus and dialogs (like changing a preference, or saving a macro), your change will not be written to the configuration file until Notepad++ exits.  So if you open up the configuration file after you have changed the preference but before you have exited Notepad++, you will _not_ see that change reflected in the file yet.  Do not be surprised by this.
+
 ## Configuration Files Location
 
 In a standard installation, the configuration files go in `%AppData%\Notepad++\`.  (For a refresher course on `%AppData%`, see the [Community Forum FAQ's `%AppData%` entry](https://community.notepad-plus-plus.org/topic/15740/faq-desk-what-is-appdata).)

--- a/content/docs/macros.md
+++ b/content/docs/macros.md
@@ -44,6 +44,11 @@ default key combination. These can later be changed (and deleted) using
 [**Settings > Shortcut Mapper**](../preferences/#shortcut-mapper).
 When saved, the macro will be available from the Macro menu or the Macro playlist.
 
+As noted in the [Configuration Files](../config-files) documentation, Notepad++
+writes the configuration files (including the macros) when it exits, which means that
+after you save your macro, your new macro will _not_ be written to the `shortcuts.xml` 
+configuration file until Notepad++ exits.  Thus, if you open `shortcuts.xml` after saving
+the macro but before exiting Notepad++, you will _not_ be able to see your new macro yet.
 
 ## Play a recoded macro multiple times
 

--- a/content/docs/preferences.md
+++ b/content/docs/preferences.md
@@ -7,6 +7,8 @@ There are three main dialogs for editing preferences and other user-defined sett
 
 For settings not covered by the three main dialogs, there are [other toggles and settings](#other-toggles-and-settings) which can be found in various dialogs, menus, and configuration files.
 
+As noted in the [Configuration Files](../config-files) documentation, Notepad++ writes the configuration files when it exits, which means that, when you make a change using Notepad++ menus and dialogs described below, your change will _not_ be written to the configuration file until Notepad++ exits.
+
 ## Preferences
 
 For the descriptions below, if it's a checkbox `☐`, the description applies if the checkbox is enabled.  (For options where the opposite behavior might not be obvious, it may also explicitly describe what the unchecked behavior is.)


### PR DESCRIPTION
per discussion around https://community.notepad-plus-plus.org/post/75574 , there may still be confusion as to when configuration files (including macros) are saved to disk.

These edits to the Config Files, Preferences, and Save Macro sections make it more clear that configuration changes are written to the files when Notepad++ exits, and will not be visible in those files until Notepad++ has exited.