### PR TITLE
Bump actions/upload-artifact from 2 to 3 (#4)

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -27,7 +27,7 @@ jobs:
            Rename-Item -Path 127.0.0.1_1313 -NewName nppUserManual
 
     - name: Archive artifacts for hugo
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: nppUserManual
           path: ./httrack_output/nppUserManual/


### PR DESCRIPTION
Dependabot updated in my fork instead of the main project; weird.  Merging it into the main project
---

Bumps [actions/upload-artifact](https://github.com/actions/upload-artifact) from 2 to 3.
- [Release notes](https://github.com/actions/upload-artifact/releases)
- [Commits](https://github.com/actions/upload-artifact/compare/v2...v3)

---
updated-dependencies:
- dependency-name: actions/upload-artifact
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>