### PR TITLE
Shortcut Mapper: clarify interaction with Windows accelerators

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -27,7 +27,7 @@ jobs:
            Rename-Item -Path 127.0.0.1_1313 -NewName nppUserManual
 
     - name: Archive artifacts for hugo
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: nppUserManual
           path: ./httrack_output/nppUserManual/

--- a/content/docs/preferences.md
+++ b/content/docs/preferences.md
@@ -548,7 +548,7 @@ The Delete button is usually disabled.  However, in the `Macros` and `Run comman
 
 The Close button will close the dialog box.
 
-_Please Note_: Notepad++ honors standard Windows behavior with keystrokes for menu accelerators: typing `Alt` with the first letter (or underlined letter) for a main menu entry will open that menu.  (Because the `X` on the right of the menu bar, which closes the active tab, was created as a menu action on the main menu bar with the name "X", it's accelerator is therefore `Alt+X`.)  If you want to define `Alt+`_Letter_ for some other action, you may do so using the Shortcut Mapper, and that accelartor will no longer work for the menu, but will instead access the action you mapped it to.
+_Please Note_: Notepad++ honors standard Windows behavior with keystrokes for menu accelerators: typing `Alt` with the first letter (or underlined letter) for a main menu entry will open that menu.  (Because the `X` on the right of the menu bar, which closes the active tab, was created as a menu action on the main menu bar with the name "X", it's accelerator is therefore `Alt+X`.)  If you want to define `Alt+`_Letter_ for some other action, you may do so using the Shortcut Mapper, and that accelerator will no longer work for the menu, but will instead access the action you mapped it to; undefining that new Mapper entry will allow Windows to treat that sequence as the accelerator again.
 
 ### Configuration file: `shortcuts.xml`
 

--- a/content/docs/preferences.md
+++ b/content/docs/preferences.md
@@ -548,7 +548,7 @@ The Delete button is usually disabled.  However, in the `Macros` and `Run comman
 
 The Close button will close the dialog box.
 
-_Please Note_: Notepad++ honors standard Windows behavior with keystrokes for menu accelerators: typing `Alt` with the first letter (or underlined letter) for a main menu entry will open that menu.  (Because the `X` on the right of the menu bar, which closes the active tab, was created as a menu action on the main menu bar with the name "X", it's accelerator is therefore `Alt+X`.)  If you want to define `Alt+`_Letter_ for some other action, you may do so using the Shortcut Mapper, and that accelerator will no longer work for the menu, but will instead access the action you mapped it to; undefining that new Mapper entry will allow Windows to treat that sequence as the accelerator again.
+_Please Note_: Notepad++ honors standard Windows behavior with keystrokes for menu accelerators: typing `Alt` with the first letter (or underlined letter) for a main menu entry will open that menu.  (Because the `X` on the right of the menu bar, which closes the active tab, was created as a menu action on the main menu bar with the name "X", it's accelerator is therefore `Alt+X`.)  If you want to define `Alt+`_Letter_ for some other action, you may do so using the Shortcut Mapper, and that accelerator will no longer work for the menu, but will instead access the action you mapped it to; undefining that new Mapper entry will allow Windows to treat that sequence as the accelerator again.  Shortcut Mapper cannot change or clear the Windows accelerator for a menu entry -- it can just preempt that accelerator key to use for something else.
 
 ### Configuration file: `shortcuts.xml`
 

--- a/content/docs/preferences.md
+++ b/content/docs/preferences.md
@@ -548,6 +548,8 @@ The Delete button is usually disabled.  However, in the `Macros` and `Run comman
 
 The Close button will close the dialog box.
 
+_Please Note_: Notepad++ honors standard Windows behavior with keystrokes for menu accelerators: typing `Alt` with the first letter (or underlined letter) for a main menu entry will open that menu.  (Because the `X` on the right of the menu bar, which closes the active tab, was created as a menu action on the main menu bar with the name "X", it's accelerator is therefore `Alt+X`.)  If you want to define `Alt+`_Letter_ for some other action, you may do so using the Shortcut Mapper, and that accelartor will no longer work for the menu, but will instead access the action you mapped it to.
+
 ### Configuration file: `shortcuts.xml`
 
 If you prefer to edit XML instead of using the GUI to modify shortcuts, you may edit the `shortcuts.xml` file.  The keyboard shortcuts are defined as attributes of the `<Macro>`, `<Command>`, `<PluginCommand>`, and `<ScintKey>` tags.  The `Key=` attribute is the decimal value for the keycode associated with the key you want to hit.  The `Ctrl=`, `Alt=`, `Shift=` attributes have values of either "yes" or "no", and either enable or disable the modifier for that key.


### PR DESCRIPTION
https://community.notepad-plus-plus.org/topic/22837/alt-x-is-an-undocumented-unreported-keyboard-shotcut-for-main-menu-file-close