### PR TITLE
v8.4.1 documentation changes

### DIFF
--- a/content/docs/command-prompt.md
+++ b/content/docs/command-prompt.md
@@ -14,7 +14,7 @@ notepad++ [--help] [-multiInst] [-noPlugin]
   [-l<Language>] [-udl="My UDL Name"]
   [-L<langCode>]
   [-n<line>] [-c<column>] [-p<pos>] [-x<left-pos>] [-y<TopPos>]
-  [-nosession] [-notabbar] [-ro] [-systemtray] [-loadingTime]
+  [-monitor] [-nosession] [-notabbar] [-ro] [-systemtray] [-loadingTime]
   [-alwaysOnTop] [-openSession] [-r]
   [-qn="Easter Egg Name" | -qt="Text to Type" | -qf="D:\path to\file"]
   [-qSpeed(1|2|3)] [-quickPrint]
@@ -47,6 +47,7 @@ notepad++ [--help] [-multiInst] [-noPlugin]
 * `-p`: Scroll to indicated 0 base position (*Position*) on `filepath`.
 * `-x`: Move Notepad++ to indicated left side position (*LeftPos*) on the screen.
 * `-y`: Move Notepad++ to indicated top position (*TopPos*) on the screen.
+* `-monitor`: Open file with [file monitoring](../views/#live-file-monitoring) enabled
 * `-nosession`: Launch Notepad++ without previous session.
 * `-notabbar`: Launch Notepad++ without tabbar.
 * `-ro`: Make the `filepath` read only.

--- a/content/docs/plugin-communication.md
+++ b/content/docs/plugin-communication.md
@@ -706,6 +706,45 @@ User is responsible to allocate a buffer which is large enough.*
 
 ---
 
+#### **NPPM_GETDARKMODECOLORS**
+*Retrieves the colors used in Dark Mode.
+User is responsible to allocate a buffer which is large enough.
+(Added v8.4.1)*
+
+**Parameters**:
+
+*wParam [in]*
+: size_t cbSize - must be filled with `sizeof(NppDarkMode::Colors)`
+
+*lParam [out]*
+: NppDarkMode::Colors* returnColors - must be a pre-allocated NppDarkMode::Colors struct
+
+**Return value**:
+: Returns True on success and False if provided currentWord buffer is not large enough
+
+**Data Structure**
+:
+```
+namespace NppDarkMode
+{
+    struct Colors
+    {
+        COLORREF background = 0;
+        COLORREF softerBackground = 0;
+        COLORREF hotBackground = 0;
+        COLORREF pureBackground = 0;
+        COLORREF errorBackground = 0;
+        COLORREF text = 0;
+        COLORREF darkerText = 0;
+        COLORREF disabledText = 0;
+        COLORREF linkText = 0;
+        COLORREF edge = 0;
+    };
+}
+```
+
+---
+
 #### **NPPM_GETEDITORDEFAULTBACKGROUNDCOLOR**
 *Retrieves the current editor default background color.*
 
@@ -1361,6 +1400,22 @@ struct ShortcutKey {
 
 ---
 
+#### **NPPM_ISDARKMODEENABLED**
+*Notepad++ Dark Mode is enable.  (Added v8.4.1)*
+
+**Parameters**:
+
+*wParam [in]*
+: int, must be zero.
+
+*lParam [in]*
+: int, must be zero.
+
+**Return value**:
+: TRUE when Notepad++ Dark Mode is enable, FALSE when it is not.
+
+---
+
 #### **NPPM_ISMENUHIDDEN**
 *Retrieves the current status of menubar.*
 
@@ -1983,6 +2038,18 @@ The general layout of the following notifications look like this
 **Fields:**
 
 	code:		NPPN_CANCELSHUTDOWN
+	hwndFrom:	hwndNpp
+	idFrom:		0
+
+---
+
+####  **NPPN_DARKMODECHANGED**
+*To notify plugins that Dark Mode was changed (either enabled or disabled).  
+(Added v8.4.1)*
+
+**Fields:**
+
+	code:		NPPN_DARKMODECHANGED
 	hwndFrom:	hwndNpp
 	idFrom:		0
 

--- a/content/docs/preferences.md
+++ b/content/docs/preferences.md
@@ -59,8 +59,13 @@ These influence editing (carets, code-folding, line wrapping, and more).
     * `☐ Default`: wraps from the last visible column to the first visible column column
     * `☐ Aligned`: wraps from the last visible column to the same indent as the start of the unwrapped line
     * `☐ Indent`: wraps from the last visible column to the next level of indent compared to the start of the unwrapped line
+* **Current Line Indicator**: Determines how the current line will be indicated.  
+    - `☐ None` : no indicator for which line is the current line.
+    - `☐ Highlight Background` : indicate the current line by highlighting the normal background color with the **Settings > Style Configurator > Global Styles > Current line background color** style's `Background colour`
+    - `☐ Frame` : indicate the current line by drawing a rectangle frame around the text of the current line, using the color defined by **Settings > Style Configurator > Global Styles > Current line background color** style's `Background colour`, and with the rectangle-line thickness defined by the **Width** slider
+        - **Width**: slider is used to set the width (in pixels) for the lines of the rectangle Frame for the current line
+    - (In v8.4 and earlier, this multi-control section was just listed as `☐ Enable current line highlighting` in the list of checkboxes, and was the equivalent of `☐` being **None** and ☑ being **Highlight Background**.)
 * `☐ Enable Multi-Editing`: allows multiple selections not necessarily contiguous with each other by using Ctrl+Mouse click on the selection(s) (was known as **Multi-Editing Settings** prior to v7.9.2)
-* `☐ Enable current line highlighting`: will change the styling of the current line of text to **Settings > Style Configurator > Global Styles > Current line background color** style's `Background colour` (ignoring the `Foreground colour` for that style)
 * `☐ Enable smooth font`: enables a font-smoothing algorithm from Windows, which may affect how smooth fonts are on some displays
 * `☐ Enable scrolling beyond last line`: allows you to scroll (with scroll bar or mouse wheel) so that up to a page of blank space _after_ the last line is visible.  (Disabled, scrolling to the end will put the last line of text as the bottom line in the window, when there are more lines of text than are visible in the window)
 * `☐ Keep selection when right-click outside of selection`: prevents right-click from canceling active selection (added v7.9)


### PR DESCRIPTION
closes #354 
- **Settings > Preferences > Editing**: change single checkbox into "Current Line Indicator" combobox trio
- `-monitor` command line argument
- API: NPPM_ISDARKMODEENABLED, NPPM_GETDARKMODECOLORS, NPPN_DARKMODECHANGED