### PR TITLE
add Find in Projects to Search Results table

### DIFF
--- a/content/docs/searching.md
+++ b/content/docs/searching.md
@@ -192,6 +192,7 @@ After running one or more **Find All in ...** commands, a new **Search results**
 |Find All in All Opened Documents   | **Find**               |
 |Find All in Current Document       | **Find**               |
 |Find All                           | **Find in Files**      |
+|Find All                           | **Find in Projects**   |
 
 The **Search results** window by default appears docked at the bottom of the Notepad++ main window.  Like other such windows, it can be moved or even be a free-floating window.
 


### PR DESCRIPTION
while answering [here](https://community.notepad-plus-plus.org/topic/22984/list-showing-only-the-results/3), I noticed that the table didn't include "Find in Projects"