### PR TITLE
Language codes

### DIFF
--- a/content/docs/command-prompt.md
+++ b/content/docs/command-prompt.md
@@ -42,7 +42,58 @@ notepad++ [--help] [-multiInst] [-noPlugin]
   quote marks aren't required around the name (like `-udl=MyUDL`). The UDL name
   should match an existing UDL.  Mutually exclusive with `-l` (UDL will take priority 
   over standard syntax highlighter).  (new to v8.1.2)
-* `-L`: Apply indicated localization, *langCode* is browser language code
+* `-L`: Apply indicated localization, *langCode* maps to the localization file name as follows:
+
+    code | file | | code | file
+    ---|---|---|---|---
+    `ab`, `abk` | `abkhazian.xml` | | `mk` | `macedonian.xml`
+    `af` | `afrikaans.xml` | | `mn` | `mongolian.xml`
+    `an` | `aragonese.xml` | | `mr` | `marathi.xml`
+    `ar`, `ar-dz`, `ar-bh`, `ar-eg`, `ar-iq`, `ar-jo`, `ar-kw`, `ar-lb`, `ar-ly`, `ar-ma`, `ar-om`, `ar-qa`, `ar-sa`, `ar-sy`, `ar-tn`, `ar-ae`, `ar-ye` | `arabic.xml` | | `ms` | `malay.xml`
+    `az` | `azerbaijani.xml` | | `ne`, `nep` | `nepali.xml`
+    `be` | `belarusian.xml` | | `nl`, `nl-be` | `dutch.xml`
+    `bg` | `bulgarian.xml` | | `nn` | `nynorsk.xml`
+    `bn` | `bengali.xml` | | `no`, `nb` | `norwegian.xml`
+    `br-fr` | `breton.xml` | | `oc-aranes` | `aranese.xml`
+    `bs` | `bosnian.xml` | | `oc` | `occitan.xml`
+    `ca` | `catalan.xml` | | `pa`, `pa-in` | `punjabi.xml`
+    `co`, `co-fr` | `corsican.xml` | | `pl` | `polish.xml`
+    `cs` | `czech.xml` | | `pt-br` | `brazilian_portuguese.xml`
+    `cy-gb` | `welsh.xml` | | `pt`, `pt-pt` | `portuguese.xml`
+    `da` | `danish.xml` | | `ro`, `ro-mo` | `romanian.xml`
+    `de`, `de-at`, `de-de`, `de-li`, `de-lu`, `de-ch` | `german.xml` | | `ru`, `ru-mo` | `russian.xml`
+    `el` | `greek.xml` | | `sc` | `sardinian.xml`
+    `eo` | `esperanto.xml` | | `sgs` | `samogitian.xml`
+    `es-ar` | `spanish_ar.xml` | | `si` | `sinhala.xml`
+    `es`, `es-bo`, `es-cl`, `es-co`, `es-cr`, `es-do`, `es-ec`, `es-sv`, `es-gt`, `es-hn`, `es-mx`, `es-ni`, `es-pa`, `es-py`, `es-pe`, `es-pr`, `es-es`, `es-uy`, `es-ve` | `spanish.xml` | | `sk` | `slovak.xml`
+    `et` | `estonian.xml` | | `sl` | `slovenian.xml`
+    `eu` | `basque.xml` | | `sq` | `albanian.xml`
+    `exy` | `extremaduran.xml` | | `sr-cyrl-ba`, `sr-cyrl-sp` | `serbianCyrillic.xml`
+    `fa` | `farsi.xml` | | `sr` | `serbian.xml`
+    `fi` | `finnish.xml` | | `sv` | `swedish.xml`
+    `fr`, `fr-be`, `fr-ca`, `fr-fr`, `fr-lu`, `fr-mc`, `fr-ch` | `french.xml` | | `ta` | `tamil.xml`
+    `fur` | `friulian.xml` | | `te` | `telugu.xml`
+    `ga` | `irish.xml` | | `tg-cyrl-tj` | `tajikCyrillic.xml`
+    `gl` | `galician.xml` | | `th` | `thai.xml`
+    `gu` | `gujarati.xml` | | `tl` | `tagalog.xml`
+    `he` | `hebrew.xml` | | `tr` | `turkish.xml`
+    `hi` | `hindi.xml` | | `tt` | `tatar.xml`
+    `hr` | `croatian.xml` | | `ug-cn` | `uyghur.xml`
+    `hu` | `hungarian.xml` | | `uk` | `ukrainian.xml`
+    `id` | `indonesian.xml` | | `ur`, `ur-pk` | `urdu.xml`
+    `it`, `it-ch` | `italian.xml` | | `uz-cyrl-uz` | `uzbekCyrillic.xml`
+    `ja` | `japanese.xml` | | `uz` | `uzbek.xml`
+    `ka` | `georgian.xml` | | `vec` | `venetian.xml`
+    `keb` | `kabyle.xml` | | `vi`, `vi-vn` | `vietnamese.xml`
+    `kk` | `kazakh.xml` | | `yue` | `hongKongCantonese.xml`
+    `kn` | `kannada.xml` | | `zh-tw`, `zh-hk`, `zh-sg` | `taiwaneseMandarin.xml`
+    `ko`, `ko-kp`, `ko-kr` | `korean.xml` | | `zh`, `zh-cn` | `chineseSimplified.xml`
+    `ku` | `kurdish.xml` | | `zu`, `zu-za` | `zulu.xml`
+    `ky` | `kyrgyz.xml` | | |
+    `lb` | `luxembourgish.xml` | | |
+    `lij` | `ligurian.xml` | | |
+    `lt` | `lithuanian.xml` | | |
+    `lv` | `latvian.xml` | | |
 * `-n`: Scroll to indicated line (*LineNumber*) on `filepath`.
 * `-c`: Scroll to indicated column (*ColumnNumber*) on `filepath`.
 * `-p`: Scroll to indicated 0 base position (*Position*) on `filepath`.

--- a/content/docs/command-prompt.md
+++ b/content/docs/command-prompt.md
@@ -10,7 +10,7 @@ to control its startup and affect its behavior.
 ## Help usage
 
 ```
-notepad++ [--help] [-multiInst] [-noPlugin] 
+notepad++ [--help] [-multiInst] [-noPlugin]
   [-l<Language>] [-udl="My UDL Name"]
   [-L<langCode>]
   [-n<line>] [-c<column>] [-p<pos>] [-x<left-pos>] [-y<TopPos>]
@@ -37,63 +37,107 @@ notepad++ [--help] [-multiInst] [-noPlugin]
   `actionscript`, `nsis`, `tcl`, `lisp`, `scheme`, `asm`, `diff`, `props`,
   `postscript`, `ruby`, `smalltalk`, `vhdl`, `kix`, `autoit`, `Gui4Cli`,
   `powershell`, `caml`, `ada`, `verilog`, `matlab`, `haskell`, `inno`, `cmake`, `yaml`, `r` and `jsp`.
-* `-udl="My UDL Name"`: Open file with User Defined Language (UDL) syntax 
+* `-udl="My UDL Name"`: Open file with User Defined Language (UDL) syntax
   highlighting `My UDL Name` active.  If the UDL name does not conain spaces, the
   quote marks aren't required around the name (like `-udl=MyUDL`). The UDL name
-  should match an existing UDL.  Mutually exclusive with `-l` (UDL will take priority 
+  should match an existing UDL.  Mutually exclusive with `-l` (UDL will take priority
   over standard syntax highlighter).  (new to v8.1.2)
-* `-L`: Apply indicated localization, *langCode* maps to the localization file name as follows:
-
-    code | file | | code | file
-    ---|---|---|---|---
-    `ab`, `abk` | `abkhazian.xml` | | `mk` | `macedonian.xml`
-    `af` | `afrikaans.xml` | | `mn` | `mongolian.xml`
-    `an` | `aragonese.xml` | | `mr` | `marathi.xml`
-    `ar`, `ar-dz`, `ar-bh`, `ar-eg`, `ar-iq`, `ar-jo`, `ar-kw`, `ar-lb`, `ar-ly`, `ar-ma`, `ar-om`, `ar-qa`, `ar-sa`, `ar-sy`, `ar-tn`, `ar-ae`, `ar-ye` | `arabic.xml` | | `ms` | `malay.xml`
-    `az` | `azerbaijani.xml` | | `ne`, `nep` | `nepali.xml`
-    `be` | `belarusian.xml` | | `nl`, `nl-be` | `dutch.xml`
-    `bg` | `bulgarian.xml` | | `nn` | `nynorsk.xml`
-    `bn` | `bengali.xml` | | `no`, `nb` | `norwegian.xml`
-    `br-fr` | `breton.xml` | | `oc-aranes` | `aranese.xml`
-    `bs` | `bosnian.xml` | | `oc` | `occitan.xml`
-    `ca` | `catalan.xml` | | `pa`, `pa-in` | `punjabi.xml`
-    `co`, `co-fr` | `corsican.xml` | | `pl` | `polish.xml`
-    `cs` | `czech.xml` | | `pt-br` | `brazilian_portuguese.xml`
-    `cy-gb` | `welsh.xml` | | `pt`, `pt-pt` | `portuguese.xml`
-    `da` | `danish.xml` | | `ro`, `ro-mo` | `romanian.xml`
-    `de`, `de-at`, `de-de`, `de-li`, `de-lu`, `de-ch` | `german.xml` | | `ru`, `ru-mo` | `russian.xml`
-    `el` | `greek.xml` | | `sc` | `sardinian.xml`
-    `eo` | `esperanto.xml` | | `sgs` | `samogitian.xml`
-    `es-ar` | `spanish_ar.xml` | | `si` | `sinhala.xml`
-    `es`, `es-bo`, `es-cl`, `es-co`, `es-cr`, `es-do`, `es-ec`, `es-sv`, `es-gt`, `es-hn`, `es-mx`, `es-ni`, `es-pa`, `es-py`, `es-pe`, `es-pr`, `es-es`, `es-uy`, `es-ve` | `spanish.xml` | | `sk` | `slovak.xml`
-    `et` | `estonian.xml` | | `sl` | `slovenian.xml`
-    `eu` | `basque.xml` | | `sq` | `albanian.xml`
-    `exy` | `extremaduran.xml` | | `sr-cyrl-ba`, `sr-cyrl-sp` | `serbianCyrillic.xml`
-    `fa` | `farsi.xml` | | `sr` | `serbian.xml`
-    `fi` | `finnish.xml` | | `sv` | `swedish.xml`
-    `fr`, `fr-be`, `fr-ca`, `fr-fr`, `fr-lu`, `fr-mc`, `fr-ch` | `french.xml` | | `ta` | `tamil.xml`
-    `fur` | `friulian.xml` | | `te` | `telugu.xml`
-    `ga` | `irish.xml` | | `tg-cyrl-tj` | `tajikCyrillic.xml`
-    `gl` | `galician.xml` | | `th` | `thai.xml`
-    `gu` | `gujarati.xml` | | `tl` | `tagalog.xml`
-    `he` | `hebrew.xml` | | `tr` | `turkish.xml`
-    `hi` | `hindi.xml` | | `tt` | `tatar.xml`
-    `hr` | `croatian.xml` | | `ug-cn` | `uyghur.xml`
-    `hu` | `hungarian.xml` | | `uk` | `ukrainian.xml`
-    `id` | `indonesian.xml` | | `ur`, `ur-pk` | `urdu.xml`
-    `it`, `it-ch` | `italian.xml` | | `uz-cyrl-uz` | `uzbekCyrillic.xml`
-    `ja` | `japanese.xml` | | `uz` | `uzbek.xml`
-    `ka` | `georgian.xml` | | `vec` | `venetian.xml`
-    `keb` | `kabyle.xml` | | `vi`, `vi-vn` | `vietnamese.xml`
-    `kk` | `kazakh.xml` | | `yue` | `hongKongCantonese.xml`
-    `kn` | `kannada.xml` | | `zh-tw`, `zh-hk`, `zh-sg` | `taiwaneseMandarin.xml`
-    `ko`, `ko-kp`, `ko-kr` | `korean.xml` | | `zh`, `zh-cn` | `chineseSimplified.xml`
-    `ku` | `kurdish.xml` | | `zu`, `zu-za` | `zulu.xml`
-    `ky` | `kyrgyz.xml` | | |
-    `lb` | `luxembourgish.xml` | | |
-    `lij` | `ligurian.xml` | | |
-    `lt` | `lithuanian.xml` | | |
-    `lv` | `latvian.xml` | | |
+* `-L`: Apply indicated localization, *langCode* maps to the localization file name:
+    {{< expand "show Language Codes" >}}
+code | file
+---|---
+`ab`, `abk` | `abkhazian.xml`
+`af` | `afrikaans.xml`
+`an` | `aragonese.xml`
+`ar`, `ar-dz`, `ar-bh`, `ar-eg`, `ar-iq`, `ar-jo`, `ar-kw`, `ar-lb`, `ar-ly`, `ar-ma`, `ar-om`, `ar-qa`, `ar-sa`, `ar-sy`, `ar-tn`, `ar-ae`, `ar-ye` | `arabic.xml`
+`az` | `azerbaijani.xml`
+`be` | `belarusian.xml`
+`bg` | `bulgarian.xml`
+`bn` | `bengali.xml`
+`br-fr` | `breton.xml`
+`bs` | `bosnian.xml`
+`ca` | `catalan.xml`
+`co`, `co-fr` | `corsican.xml`
+`cs` | `czech.xml`
+`cy-gb` | `welsh.xml`
+`da` | `danish.xml`
+`de`, `de-at`, `de-de`, `de-li`, `de-lu`, `de-ch` | `german.xml`
+`el` | `greek.xml`
+`eo` | `esperanto.xml`
+`es-ar` | `spanish_ar.xml`
+`es`, `es-bo`, `es-cl`, `es-co`, `es-cr`, `es-do`, `es-ec`, `es-sv`, `es-gt`, `es-hn`, `es-mx`, `es-ni`, `es-pa`, `es-py`, `es-pe`, `es-pr`, `es-es`, `es-uy`, `es-ve` | `spanish.xml`
+`et` | `estonian.xml`
+`eu` | `basque.xml`
+`exy` | `extremaduran.xml`
+`fa` | `farsi.xml`
+`fi` | `finnish.xml`
+`fr`, `fr-be`, `fr-ca`, `fr-fr`, `fr-lu`, `fr-mc`, `fr-ch` | `french.xml`
+`fur` | `friulian.xml`
+`ga` | `irish.xml`
+`gl` | `galician.xml`
+`gu` | `gujarati.xml`
+`he` | `hebrew.xml`
+`hi` | `hindi.xml`
+`hr` | `croatian.xml`
+`hu` | `hungarian.xml`
+`id` | `indonesian.xml`
+`it`, `it-ch` | `italian.xml`
+`ja` | `japanese.xml`
+`ka` | `georgian.xml`
+`keb` | `kabyle.xml`
+`kk` | `kazakh.xml`
+`kn` | `kannada.xml`
+`ko`, `ko-kp`, `ko-kr` | `korean.xml`
+`ku` | `kurdish.xml`
+`ky` | `kyrgyz.xml`
+`lb` | `luxembourgish.xml`
+`lij` | `ligurian.xml`
+`lt` | `lithuanian.xml`
+`lv` | `latvian.xml`
+`mk` | `macedonian.xml`
+`mn` | `mongolian.xml`
+`mr` | `marathi.xml`
+`ms` | `malay.xml`
+`ne`, `nep` | `nepali.xml`
+`nl`, `nl-be` | `dutch.xml`
+`nn` | `nynorsk.xml`
+`no`, `nb` | `norwegian.xml`
+`oc-aranes` | `aranese.xml`
+`oc` | `occitan.xml`
+`pa`, `pa-in` | `punjabi.xml`
+`pl` | `polish.xml`
+`pt-br` | `brazilian_portuguese.xml`
+`pt`, `pt-pt` | `portuguese.xml`
+`ro`, `ro-mo` | `romanian.xml`
+`ru`, `ru-mo` | `russian.xml`
+`sc` | `sardinian.xml`
+`sgs` | `samogitian.xml`
+`si` | `sinhala.xml`
+`sk` | `slovak.xml`
+`sl` | `slovenian.xml`
+`sq` | `albanian.xml`
+`sr-cyrl-ba`, `sr-cyrl-sp` | `serbianCyrillic.xml`
+`sr` | `serbian.xml`
+`sv` | `swedish.xml`
+`ta` | `tamil.xml`
+`te` | `telugu.xml`
+`tg-cyrl-tj` | `tajikCyrillic.xml`
+`th` | `thai.xml`
+`tl` | `tagalog.xml`
+`tr` | `turkish.xml`
+`tt` | `tatar.xml`
+`ug-cn` | `uyghur.xml`
+`uk` | `ukrainian.xml`
+`ur`, `ur-pk` | `urdu.xml`
+`uz-cyrl-uz` | `uzbekCyrillic.xml`
+`uz` | `uzbek.xml`
+`vec` | `venetian.xml`
+`vi`, `vi-vn` | `vietnamese.xml`
+`yue` | `hongKongCantonese.xml`
+`zh-tw`, `zh-hk`, `zh-sg` | `taiwaneseMandarin.xml`
+`zh`, `zh-cn` | `chineseSimplified.xml`
+`zu`, `zu-za` | `zulu.xml`
+    {{< /expand >}}
 * `-n`: Scroll to indicated line (*LineNumber*) on `filepath`.
 * `-c`: Scroll to indicated column (*ColumnNumber*) on `filepath`.
 * `-p`: Scroll to indicated 0 base position (*Position*) on `filepath`.
@@ -130,6 +174,7 @@ as you should always quote the filename.
 This help usage list can be accessed inside Notepad++ using the `--help` command
 line argument, or using the **?**-menu's **Command Line Arguments** entry.
 
+
 ### Additional Options
 
 There are other Notepad++ command-line options which aren't included in the help
@@ -141,7 +186,7 @@ usage list.  These are intended for advanced usage or other special circumstance
   a command-line option when you try to print the file from the Explorer Context menu.
   Enabling this option allows Notepad++ to recognize that option, and convert it internally
   to the official `-quickPrint` option.
-* `-z`: Strips out any command line arguments found after this option. Its only intended and 
+* `-z`: Strips out any command line arguments found after this option. Its only intended and
   supported use is for the [Notepad Replacement](../other-resources/#notepad-replacement)
 
 ## Installer Options


### PR DESCRIPTION
add a hidden[/](# "yay hugo! glad I learned of that {{% expand %}} shortcode")expandable table that lists all the language codes that Notepad++ currently accepts

closes #372 