### PR TITLE
cursor -> caret

### DIFF
--- a/content/docs/auto-completion.md
+++ b/content/docs/auto-completion.md
@@ -21,7 +21,7 @@ These function lists are stored in auto-completion definition files, each named 
 
 The auto-complete definition file can specify if a keyword is a function. When a function name has been typed in, followed by the opening parenthesis used to enclose the function's arguments, Notepad++ will automatically, or manually, display a hint (a.k.a. a "call tip"): a small tooltip-style box opens with text containing a description of the function. While the actual text shown is up to the author of the definition file, typically this would show, at minimum, a keyword for each of the parameters taken by the function call. This may save you a trip to the function's documentation to remember what those parameters are.
 
-Notepad++ will display the hint automatically when the open-parenthesis is typed, if that option is selected in the Auto-Completion settings. The user can also select the "Function parameters hint" from the menu or by keystroke (default: `Ctrl+Shift+Space`), when the cursor is between the opening and closing parentheses of the function call. And again, the hint can be dismissed with Esc.
+Notepad++ will display the hint automatically when the open-parenthesis is typed, if that option is selected in the Auto-Completion settings. The user can also select the "Function parameters hint" from the menu or by keystroke (default: `Ctrl+Shift+Space`), when the caret is between the opening and closing parentheses of the function call. And again, the hint can be dismissed with Esc.
 
 ## Word completion
 
@@ -29,7 +29,7 @@ Notepad++ will display the hint automatically when the open-parenthesis is typed
 
 ## Path completion
 
-Different from function and word completion which can be triggered automatically after 1 (or X) keystroke(s), Path completion needs to be triggered manually, by using shortcut (default: `Ctrl+Alt+Space`) or via menu command **Edit > Auto-Completion > Path Completion** after typing the drive (for example "C:"). If the string on the left of cursor is not part of one of the system paths, the path list won't appear.
+Different from function and word completion which can be triggered automatically after 1 (or X) keystroke(s), Path completion needs to be triggered manually, by using shortcut (default: `Ctrl+Alt+Space`) or via menu command **Edit > Auto-Completion > Path Completion** after typing the drive (for example "C:"). If the string on the left of caret is not part of one of the system paths, the path list won't appear.
 
 ## How to make it work
 
@@ -57,9 +57,9 @@ Some characters traditionally work in pairs, so that it makes sense to ask an ed
 
 Through [**Settings > Preferences > Auto-Completion**](../preferences/#auto-completion), the **Auto-Insert** options allow selection of any or all of five predefined characters—parenthesis, bracket, brace, double-quote and single quote (apostrophe)—to be automatically matched. Not only that, three custom pairs of characters may be specified. For instance, you might use Unicode open- and close- double quotes; with this feature, you can have both characters inserted when you type the opening quote mark. (Only single characters are allowed in these fields.)
 
-In each case, when the opening character is typed, the closing character will automatically be inserted, with the cursor placed between the two.
+In each case, when the opening character is typed, the closing character will automatically be inserted, with the caret placed between the two.
 
-Additionally, Auto-Insert supports automatic HTML & XML tag closure. With this enabled, when editing HTML or XML files, after you type an opening tag, such as `<div>`, the program will automatically match it with the closing `</div>`, with the cursor placed between the two tags so that content can be added. Matching will work even if attributes are entered while typing the opening tag. And if the opening tag is terminated with a slash (`/`) —such as `<hr/>` —then no matching tag is inserted. (In the case of `<hr>` entered without a slash, a matching close tag will still be inserted, even if unnecessary, for both HTML and XML editing. Consider this a push towards XML correctness in your HTML code.)
+Additionally, Auto-Insert supports automatic HTML & XML tag closure. With this enabled, when editing HTML or XML files, after you type an opening tag, such as `<div>`, the program will automatically match it with the closing `</div>`, with the caret placed between the two tags so that content can be added. Matching will work even if attributes are entered while typing the opening tag. And if the opening tag is terminated with a slash (`/`) —such as `<hr/>` —then no matching tag is inserted. (In the case of `<hr>` entered without a slash, a matching close tag will still be inserted, even if unnecessary, for both HTML and XML editing. Consider this a push towards XML correctness in your HTML code.)
 
 ### Displayed Completion List
 

--- a/content/docs/config-files.md
+++ b/content/docs/config-files.md
@@ -45,7 +45,7 @@ The `config.xml` file may be overwritten by Notepad++ on exit, even if you follo
 
 ## Configuration Files during Upgrades
 
-When you use the installer to upgrade your existing copy of Notepad++ (either manually, or through the **?**-menu's **Upgrade Notepad++**, or through Notepad++'s auto-update feature), the installer will avoid overwriting configuration files that you have customized -- this is to prevent you losing your preferred settings and customizations.  
+When you use the installer to upgrade your existing copy of Notepad++ (either manually, or through the **?**-menu's **Upgrade Notepad++**, or through Notepad++'s auto-update feature), the installer will avoid overwriting configuration files that you have customized -- this is to prevent you losing your preferred settings and customizations.
 
 However, this means that occasionally, updated functionList parsing files or themes, or new keywords in langs.xml, or new default contextMenu or shortcuts entries might not be added to your local copy of Notepad++.  So if you upgrade and keep your existing configuration, it is a good idea to occasionally compare your configuration files to the "standard/default" configuration files: some of the config files come with `*.model.xml` versions in the installation directory, which show you the default settings for those files; for other configuration files, you could [download](https://notepad-plus-plus.org/downloads/) a portable zipfile of the same version you are using, and compare the config files from the portable to your installed; and you can always look in the [source code repository](https://github.com/notepad-plus-plus/notepad-plus-plus/) for the various configuration files.  (You can use two [Views](../views/) to look at the files side-by-side, and the [synchronized scrolling feature](../views/#synchronized-scrolling) can help keep the copies aligned; plugins such as the Compare plugin are designed to show differences between files as well.)
 
@@ -164,10 +164,10 @@ CURRENT_DIRECTORY   | The active file's directory       | `E:\My Web\main`
 FILE_NAME           | The active file's name            | `welcome.html`
 NAME_PART           | The filename without extension    | `welcome`
 EXT_PART            | The extension (with the `.`)      | `.html`
-CURRENT_WORD        | the active selection in Notepad++, or the word under the cursor |
-CURRENT_LINE        | the line number where the cursor is currently located in the editor window | `1`
+CURRENT_WORD        | the active selection in Notepad++, or the word under the caret |
+CURRENT_LINE        | the line number where the caret is currently located in the editor window | `1`
 CURRENT_LINESTR     | the text of the current line (added v8.3.2)  | `The quick brown fox jumps over the lazy dog`
-CURRENT_COLUMN      | the column number where the cursor is currently located in the editor window | `5`
+CURRENT_COLUMN      | the column number where the caret is currently located in the editor window | `5`
 NPP_DIRECTORY       | the directory where the `notepad++.exe` executable is located | `c:\Program Files\notepad++`
 NPP_FULL_FILE_PATH  | the full path to the `notepad++.exe` | `c:\Program Files\notepad++\notepad++.exe`
 
@@ -326,7 +326,7 @@ _Notes_:
         <ToolBarIcons icoFolderName="myAwesomeIcons" />
     </NotepadPlus>
     ```
-    
+
 * Note 2: This is the same folder descibed in [Configuration Files Locations](#configuration-files-location) where `config.xml` goes, and will generally be the `%APPDATA%\Notepad++\` directory, unless you are using local configuration or cloud configuration or overriding the configuration directory with `-settingsDir`.
 
 * Note 3: If the `icoFolderName` value is an empty string, the path of icons will be `[toolbarIcons.xml's folder]\toolbarIcons\default\` folder.

--- a/content/docs/editing.md
+++ b/content/docs/editing.md
@@ -27,11 +27,11 @@ The Column Editor dialog, accessed via **Edit > Column Editor**, allows you to i
 
 ## Multi-Editing
 
-Multi-Editing mode allows you to make multiple cursor selections by using `Ctrl+Click` for each additional cursor.  This allows performing the same editing actions (typing, copy/cut/paste/delete, arrowing through the text) in multiple locations, even if they aren't lined up in a nice column, or even if there are lines between the cursors that you don't want to affect.
+Multi-Editing mode allows you to make multiple caret selections by using `Ctrl+Click` for each additional caret.  This allows performing the same editing actions (typing, copy/cut/paste/delete, arrowing through the text) in multiple locations, even if they aren't lined up in a nice column, or even if there are lines between the carets that you don't want to affect.
 
 ![](../images/multiEdit.gif)
 
-Whether or not you can use Multi-Editing mode is determined by the [Settings > Preferences > Editing > ☑ Enable Multi-Editing (Ctrl+Mouse click/selection](../preferences/#editing) checkbox: with it checkmarked, `Ctrl+Click` will add cursor locations; with it not checkmarked, Multi-Editing is disabled.
+Whether or not you can use Multi-Editing mode is determined by the [Settings > Preferences > Editing > ☑ Enable Multi-Editing (Ctrl+Mouse click/selection](../preferences/#editing) checkbox: with it checkmarked, `Ctrl+Click` will add caret locations; with it not checkmarked, Multi-Editing is disabled.
 
 
 ## Dual View

--- a/content/docs/macros.md
+++ b/content/docs/macros.md
@@ -9,8 +9,8 @@ a document, and replaying those later on to avoid having to repeat that sequence
 of actions. This is called a macro and can save a great deal of time. Macros
 can be played once, or multiple times, even as long as is required to run through
 an entire document. You can save them for later use and assign keystrokes to
-them for fast access (See [Shortcut Mapper](../preferences/#shortcut-mapper)). 
-Macros are sensitive to the current position of the cursor and will (normally 
+them for fast access (See [Shortcut Mapper](../preferences/#shortcut-mapper)).
+Macros are sensitive to the current position of the caret and will (normally
 speaking) operate relative to it.
 
 
@@ -23,7 +23,7 @@ certain actions you perform.
 To stop recording, select **Macro > Stop Recording** or select the  button on the
 toolbar. As an exception to most commands, you can toggle this behavior with a
 special shortcut combination that is not listed in the menu but solely in the
-Shortcut mapper (see [Shortcut Mapper](../preferences/#shortcut-mapper)). 
+Shortcut mapper (see [Shortcut Mapper](../preferences/#shortcut-mapper)).
 By default, this is the combination Ctrl-Shift-R.
 
 After the recording is stopped, it will be stored in a temporary buffer. If you
@@ -42,15 +42,15 @@ This will perform the macro once at the current position.
 To save the macro in the buffer, select **Macro > Save current recorded macro** or
 press the toolbar button. A dialog will pop up asking for a name of the macro and the
 default key combination. These can later be changed (or deleted) using
-**Macro > Modify Shortcut / Delete Macro**, which brings up the 
+**Macro > Modify Shortcut / Delete Macro**, which brings up the
 [**Settings > Shortcut Mapper**](../preferences/#shortcut-mapper) on the **Macros** tab.
 When saved, the macro will be available in the bottom section of the **Macro** menu, or
-from the pulldown in the dialog accessed from the **Macro > Run a Macro Multiple Times** 
+from the pulldown in the dialog accessed from the **Macro > Run a Macro Multiple Times**
 menu entry.
 
 As noted in the [Configuration Files](../config-files) documentation, Notepad++
 writes the configuration files (including the macros) when it exits, which means that
-after you save your macro, your new macro will _not_ be written to the `shortcuts.xml` 
+after you save your macro, your new macro will _not_ be written to the `shortcuts.xml`
 configuration file until Notepad++ exits.  Thus, if you open `shortcuts.xml` after saving
 the macro but before exiting Notepad++, you will _not_ be able to see your new macro yet.
 
@@ -60,10 +60,10 @@ To play the current macro in the buffer or any saved macro once or multiple
 times, select **Macro > Run a Macro Multiple Times**... or press the button.
 A dialog will pop up allowing you to select what macro to perform (buffer
 macro or any saved macro) and how many times. You can also opt to perform the
-macro until the cursor reaches the end of the current file (starting from
+macro until the caret reaches the end of the current file (starting from
 its current position).
 
-Note that if no macros are available, this menu option is greyed out, and 
+Note that if no macros are available, this menu option is greyed out, and
 the dialog is inaccessible.
 
 
@@ -72,9 +72,9 @@ the dialog is inaccessible.
 To edit or delete an existing macro shortcut, you can use the Shortcut mapper,
 which displays all shortcuts of all kinds, and allows changing or removing a key
 binding. The interface is also available through the **Macro > Modify
-shortcut / Delete macro** menu entry. 
+shortcut / Delete macro** menu entry.
 
-The contents of a macro definition can be edited only in the `shortcuts.xml` 
+The contents of a macro definition can be edited only in the `shortcuts.xml`
 file: there is no built-in interface in Notepad++.  For more information on
-the details of how the macros are stored, and the syntax involved, see the 
+the details of how the macros are stored, and the syntax involved, see the
 [**Configuration Files Details**: **<Macros>** section](../config-files/#macros).

--- a/content/docs/preferences.md
+++ b/content/docs/preferences.md
@@ -47,7 +47,7 @@ These affect the user interface (localization, toolbar, tab bar, and more).
     * `☐ Show close button on each tab`: add the close button to each tab's entry on the tab bar
     * `☐ Double click to close document`: allows double-clicking on the tab to close the file
     * `☐ Exit on close the last tab`: if the last tab is closed, Notepad++ will exit (unselected, Notepad++ instead has one new file open)
-* `☐ Show status bar`: there will be a Status Bar along the bottom of the Notepad++ window, showing file type, cursor location, line-ending style, encoding, and INS/DEL mode.
+* `☐ Show status bar`: there will be a Status Bar along the bottom of the Notepad++ window, showing file type, caret location, line-ending style, encoding, and INS/DEL mode.
 * `☐ Hide menu bar (use Alt or F10 key to toggle)`: sets the main menu bar (File, Edit, Search, ...) invisible; once invisible, it can be made temporarily visible by using the Alt or F10 key
 
 ### Editing
@@ -250,7 +250,7 @@ Affects how the text is formatted when sent to the printer
 * **Margin Setting (Unit:mm)**: define the page margins, in mm
 * **Header and Footer**: define what will be printed in each page's header and footer sections
     * Click in one of the `Left part`, `middle part`, or `right part` for header or footer;
-    * either type in text for literal text, or use the `Variable:` drop-down and `Add` button to add one of the variables at the current cursor position
+    * either type in text for literal text, or use the `Variable:` drop-down and `Add` button to add one of the variables at the current caret position
         * Add **Full file name path** ⇒ `$(FULL_CURRENT_PATH)` in the input box ⇒ will print something like `c:\path\to\file.txt`
         * Add **File name** ⇒ `$(FILE_NAME)` in the input box ⇒ will print something like `file.txt`
         * Add **File directory** ⇒ `$(CURRENT_DIRECTORY)` in the input box ⇒ will print something like `c:\path\to`
@@ -420,7 +420,7 @@ Sets the characters that are considered part of a "word" for quick selections us
 
 ### Search Engine
 
-Set your search engine for "Search on Internet" command (found in the **Edit > On Selection** menu, or in the right-click context menu).  It will search for the word under the cursor (or for the whole selection, if a selection is made).
+Set your search engine for "Search on Internet" command (found in the **Edit > On Selection** menu, or in the right-click context menu).  It will search for the word under the caret (or for the whole selection, if a selection is made).
 
 If you want to specify a search engine not listed, type the full URL, with the text `$(CURRENT_WORD)` as the placeholder for the search term (as shown in the example in the Preferences dialog box)
 
@@ -440,7 +440,7 @@ A variety of settings that didn't fit elsewhere
         * `Enable for all open files`: for all active files, check periodically to see if the file has been updated on disk
         * `Disable`: will not check to see if the file has been updated on disk
     * `☐ Update silently`: instead of prompting, will automatically reload the file from disk
-    * `☐ Scroll to the last line after update`: will scroll to the end of the file after reloading from disk (otherwise, the cursor and scrolled-location stays where it was before the update)
+    * `☐ Scroll to the last line after update`: will scroll to the end of the file after reloading from disk (otherwise, the caret and scrolled-location stays where it was before the update)
 * `☐ Enable Notepad++ auto-updater`: will automatically download updates from the official website, once the development team has decided it's time to push an update to users.  If disabled, you will have to manually download the installer from the official website yourself.
 * `☐ Mute all sounds`: enable/disable sound feedback (example: if a search action in [**Find / Replace dialog**](../searching/#dialog-based-searching) results in the text not being encountered).
 * `☐ Autodetect character encoding`: when opening a new file, try to algorithmically determine what character encoding should be used
@@ -478,15 +478,15 @@ Some of these styles apply to the background only, some apply to the foreground 
 * Global override [background and foreground] ⇒ This style has a series of checkboxes, which allow you to choose which attributes of the override-style will apply to everything; any that are enabled will override even the per-language settings; any that are not enabled will not use the global-override settings for that attribute.
 * Default style [background and foreground] ⇒ This sets the base font and colours for all languages -- so any unstyled text will use these settings.
 * Indent guideline style [background and foreground] ⇒ If **View > Show Symbol > Show Indent Guide** is enabled, there will be a thin dotted line every for every level of indent.  The foreground sets the colour of the dots; the background sets the colour of the non-dot portion.
-* Brace highlight style [background and foreground] ⇒ If you have text like `( blah )` or `[ blah ]` or `{ blah }` and move the cursor onto one of the opening or closing parentheses, brackets, or braces, both the opening and closing character in the pair will be highlighted per this style.
-* Bad brace colour [background and foreground] ⇒ If you have a single unmatched or mismatched parenthesis `()`, bracket `[]`, or curly-brace `{}`, with the cursor at that character, it will be highlighted as a "bad brace style" instead of using the "brace highlight style".
-* Current line background colour [background only] ⇒ The line containing the active editing cursor will be marked using this background style.
+* Brace highlight style [background and foreground] ⇒ If you have text like `( blah )` or `[ blah ]` or `{ blah }` and move the caret onto one of the opening or closing parentheses, brackets, or braces, both the opening and closing character in the pair will be highlighted per this style.
+* Bad brace colour [background and foreground] ⇒ If you have a single unmatched or mismatched parenthesis `()`, bracket `[]`, or curly-brace `{}`, with the caret at that character, it will be highlighted as a "bad brace style" instead of using the "brace highlight style".
+* Current line background colour [background only] ⇒ The line containing the active editing caret will be marked using this background style.
 * Selected text colour [background only] ⇒ Selected text will be indicated with this background. If [Preferences > Highlighting > Smart Highlighting](#highlighting) is enabled, the "Smart Highlighting" style (below) will be coloured overtop of the "Selected text colour". If the [configuration file `enableSelectFgColor.xml`](../config-files#other-configuration-files) exists (and you have v8.0.0 or newer), "Selected text colour" will honor the foreground colour as well.
-* Caret colour [foreground only] ⇒ This sets the colour for the current-text-position cursor ("caret"), which will either be `|` for insert mode or `_` for overwrite mode.
+* Caret colour [foreground only] ⇒ This sets the colour for the current-text-position caret, which will either be `|` for insert mode or `_` for overwrite mode.
 * Edge colour [foreground only] ⇒ Colour for the vertical edge from [Preferences > Editing](#editing).  If the Vertical Edge Settings are enabled as Background Mode, this style's "foreground" colour will be used as the background colour for text that's beyond the edge.
 * Line number margin [background and foreground] ⇒ If "Display line number" is enabled in [Preferences > Editing](#editing), this sets the style for those line numbers.
-* Fold [background and foreground] ⇒ If a given language has folding, this will give the colour for the folding symbols (`⊞ ⊟ │ └`) when the cursor is _not_ inside that folding-area
-* Fold active [foreground only] ⇒ If a given language has folding, this will give the colour for the folding symbols (`⊞ ⊟ │ └`) when the cursor _is_ inside that folding-area
+* Fold [background and foreground] ⇒ If a given language has folding, this will give the colour for the folding symbols (`⊞ ⊟ │ └`) when the caret is _not_ inside that folding-area
+* Fold active [foreground only] ⇒ If a given language has folding, this will give the colour for the folding symbols (`⊞ ⊟ │ └`) when the caret _is_ inside that folding-area
 * Fold margin [background and foreground] ⇒ If a given language has folding, this will give the colours for the margin-region; it will be coloured with a checkerboard-like pattern (a dense version of `░`)
 * White space symbol [foreground only] ⇒ If **View > Show Symbol** settings have whitespace shown, then the tabs and whitespace symbols will use this foreground colour.
 * Smart Highlighting [background only] ⇒ If [Smart Highlighting](#highlighting) is enabled and active, this colour will be applied to all matches.  This background colour has approximately 60% transparency compared to other backgrounds also applied on the same text, so the exact colour seen will depend on other styles for this text, combined with this setting.  (For example, if you have a highlight of green RGB=[0,255,0], with a white RGB=[255,255,255] background, the actual colour will be RGB=[155,255,155].)
@@ -503,7 +503,7 @@ Some of these styles apply to the background only, some apply to the foreground 
 * Active tab unfocused indicator [foreground only] ⇒ If [Preferences > General > Draw a coloured bar on active tab](#highlighting) is enabled, and if both editor views are visible, this foreground colour will be used for drawing a thick bar along the long edge of the tab name of the other inactive view's active tab.
 * Active tab text [foreground only] ⇒ Selects the colour to be used for the filename displayed in the titlebar of the active tab.
 * Inactive tabs [background and foreground] ⇒ Selects the colour to be used for the filename displayed in the titlebars of all inactive tabs.
-* URL hovered [foreground only] ⇒ If [Preferences > MISC. > Clickable Link](#misc) is enabled, when your cursor is hovering over a URL, the URL's foreground colour will follow this setting.
+* URL hovered [foreground only] ⇒ If [Preferences > MISC. > Clickable Link](#misc) is enabled, when your mouse cursor is hovering over a URL, or if the caret is inside the URL text, then the URL's foreground colour will follow this setting.
 * Document map [background and foreground] ⇒ The foreground color will be semi-transparently overlayed over the miniature version of text that's currently visible in the editor; the background color will be semi-transparently overlayed over the miniature version of the text that isn't currently visible in the editor (this style is new to v8.1.5).
 * EOL Custom Color [background and foreground] ⇒ Sets the colors for the `CR`, `LF`, and `CRLF` indicators, which are also influenced by the [**Settings > Preferences > Editing > EOL** settings](#editing)
 

--- a/content/docs/searching.md
+++ b/content/docs/searching.md
@@ -43,7 +43,7 @@ All the dialog-based have certain features in common, though some are disabled u
 
 * **☐ In selection**: If you have a region of text selected, and **In selection** is enabled, it will only **Count**, **Replace All**, or **Mark All** within that selection of text, rather than in the whole document (other buttons, such as **Find Next**, will continue to work on the whole document)
 * **☐ Backward direction**: normally, searches go forward (down the page); with this option, they will go backward (up the page)
-* **☐ Match whole word only**: if enabled, searches will only match if the result is a whole word (so "it" will not be found inside "hitch").  
+* **☐ Match whole word only**: if enabled, searches will only match if the result is a whole word (so "it" will not be found inside "hitch").
     * For ASCII text (text that only has newlines, tabs, and characters with codepoints 32 - 126):
         - If the left and right characters of your search string are both "word characters" (letters, numbers, underscore, and [optionally](https://npp-user-manual.org/docs/preferences/#delimiter "NPP User Manual: Delimiter settings") additional characters set by your preferences), then **Match whole word only** will only allow a match if the characters to the left and right of the match are _non_-word-characters or spaces or the beginning or ending of the line.
         - If the left and right characters of your search string are both non-word characters (so _not_ letters, numbers, underscore, and [optionally](https://npp-user-manual.org/docs/preferences/#delimiter "NPP User Manual: Delimiter settings") additional characters set by your preferences), then the text to the left and right of your match must be word charcters, spaces, and/or beginning or ending of the line.
@@ -121,25 +121,25 @@ If a search action is invoked by keyboard command with the Find dialog window op
 
 ### Find in Files tab
 
-Find in Files allows both finding and replacing. You can choose an extension filter (**Filters:**), the containing folder (**Directory:**), and whether to also process hidden files or subfolders.  
+Find in Files allows both finding and replacing. You can choose an extension filter (**Filters:**), the containing folder (**Directory:**), and whether to also process hidden files or subfolders.
 
-The **Filters** list is a space-separated list of wildcard expressions that cmd.exe can understand, like `*.doc foo.*`.   
+The **Filters** list is a space-separated list of wildcard expressions that cmd.exe can understand, like `*.doc foo.*`.
 
 * Wildcards can include `*` for zero or more of any character, and `?` for exactly one of any character.
 * Most characters work as literals.  However, space is used as the separator, and thus cannot be used as a literal in your filter.  Some punctuation characters have special meanings (like the `?` and `*` wildcards, or the `!` exclusion or `!+\` for recursive exclusion), and cannot be used as literals.  Also, the `;` causes problems, so even though Microsoft _allows_ it in file and path names, using a `;` in the **Filters** box will not work as you might hope.  If you want to match a space or a semicolon `;` or other problematic-punctuation in your file or folder for your **Filter** (whether for inclusion or exclusion), then use the `*` and/or `?` wildcards instead.  (So `x?y.txt` will match the file `x;y.txt` or `x y.txt` (with a space between `x` and `y`).)  And sorry, no, you cannot use quotes around a path-with-spaces to allow the spaces to work as literals: the space is a separator in this field.
-* If you have a blank filter, it is implied to be `*.*`.  
-* As of Notepad++ v7.8.2, you can also exclude certain file patterns by prefixing the filter with a `!`; 
-for example, **Filters:  `!*.bin *.*`** will exclude files matching `*.bin` from the search results, but include any other filename.  (Before v7.8.7, if you had at least one exclusion in your filter, you needed to have at least one inclusion in your filter, otherwise it excluded files from the 0 matched inclusion files, resulting in no files matched, which probably isn't what you wanted.  This was fixed in v7.8.7, so now you can have a lone exclusion like `!*.bin` and have it match any file not ending in `.bin`.)  
+* If you have a blank filter, it is implied to be `*.*`.
+* As of Notepad++ v7.8.2, you can also exclude certain file patterns by prefixing the filter with a `!`;
+for example, **Filters:  `!*.bin *.*`** will exclude files matching `*.bin` from the search results, but include any other filename.  (Before v7.8.7, if you had at least one exclusion in your filter, you needed to have at least one inclusion in your filter, otherwise it excluded files from the 0 matched inclusion files, resulting in no files matched, which probably isn't what you wanted.  This was fixed in v7.8.7, so now you can have a lone exclusion like `!*.bin` and have it match any file not ending in `.bin`.)
 * As of Notepad++ v8.2, you can also exclude particular folders from the search: Exclusion operator is alway `!` at the begining. In order to distinguish folder from file, `\` should be used as prefix of the folder name/pattern, following `!`. That allows the exclusion of the directories under the root directory you want to search (the 1st level of matched directories).
 If users need to exclude folders with the same name (or names matched the specific pattern) in all levels, the `+` should be put between `!` and `\` to exclude them recursively. For example:
     * `!\tests` will not search any files in the `tests` folder
     * `!\bin*` will not search any files in the `bin` folder or `bin64` folder (or any other directory that matches `bin*`)
     * `!+\log*` will _recursively_ not search any files in folders that start with log (so directories like `.\log`, `.\logs`, `.\other\logfiles`, `.\many\layers\deep\log` will all be excluded from the search)
-    
+
     *Note*: "inclusion of folder" is not allowed, and such pattern will be ignored
-    
-* As of Notepad++ v8.2, if you hover your cursor over the **Filters:** label, a helpful popup will show example syntax for you
-* Please also note that the PathMatchSpec() Windows API is being used for the **Filters**, as its behavior departs from cmd.exe wildcard parsing sometimes.  
+
+* As of Notepad++ v8.2, if you hover your mouse cursor over the **Filters:** label, a helpful popup will show example syntax for you
+* Please also note that the PathMatchSpec() Windows API is being used for the **Filters**, as its behavior departs from cmd.exe wildcard parsing sometimes.
 
 The **Directory** is the containing folder for where to search.  It has three options that affect its behavior:
 
@@ -228,7 +228,7 @@ There are two ways to copy exact text from the **Search results** window:  Make 
 
 Here's a more detailed description of what happens for *RightClick* > **Copy Selected Line(s)**:
 
-First, if the user makes a selection of text in the **Search results** window and copies it this way, only the lines of text touched (even partially) by the selection are part of the copy.  All other text with information about the search (pathname, line number, etc.) is *not* copied, even if part of the selection.  Secondly, if there is no active selection when the *RightClick* > **Copy Selected Line(s)** is invoked, results depend upon what exactly is under the cursor during the *RightClick*:
+First, if the user makes a selection of text in the **Search results** window and copies it this way, only the lines of text touched (even partially) by the selection are part of the copy.  All other text with information about the search (pathname, line number, etc.) is *not* copied, even if part of the selection.  Secondly, if there is no active selection when the *RightClick* > **Copy Selected Line(s)** is invoked, results depend upon what exactly is under the mouse cursor during the *RightClick*:
 
 | *RightClick* item     | What gets copied when *RightClick* > **Copy Selected Line(s)** is run |
 |-----------------------|-----------------------------------------------------------------------------------------------------|
@@ -394,9 +394,9 @@ In a regular expression (shortened into regex throughout), special characters in
 
 * `\X` ⇒ Matches a single non-combining character followed by any number of combining characters. This is useful if you have a Unicode encoded text with accents as separate, combining characters.  For example, the letter `ǭ̳̚`, with four combining characters after the `o`, can be found either with the regex `(?-i)o\x{0304}\x{0328}\x{031a}\x{0333}` or with the shorter regex `\X`.
 
-* `\$` , `\(` , `\)` , `\*` , `\+` , `\.` , `\?` , `\[` , `\]` , `\\` , `\|` ⇒ Prefixing a special character with `\` to "escape" the character allows you to search for a literal character when the regular expression syntax would otherwise have that character have a special meaning as a regex meta-character.   
-    * The characters `$ ( ) * + . ? [ ] \ |` all have special meaning to the regex engine in normal circumstances; to get them to match as a literal (or to show up as a literal in the substitution), you will have to prefix them with the `\` character.  
-    * There are also other characters which are special only in certain circumstances (any time a charcter is used with a non-literal meaning throughout the Regular Expression section of this manual); if you want to match one of those sometimes-special characters as literal character _in those situations_, those sometimes-special characters will also have to be escaped _in those situations_ by putting a `\` before it.  
+* `\$` , `\(` , `\)` , `\*` , `\+` , `\.` , `\?` , `\[` , `\]` , `\\` , `\|` ⇒ Prefixing a special character with `\` to "escape" the character allows you to search for a literal character when the regular expression syntax would otherwise have that character have a special meaning as a regex meta-character.
+    * The characters `$ ( ) * + . ? [ ] \ |` all have special meaning to the regex engine in normal circumstances; to get them to match as a literal (or to show up as a literal in the substitution), you will have to prefix them with the `\` character.
+    * There are also other characters which are special only in certain circumstances (any time a charcter is used with a non-literal meaning throughout the Regular Expression section of this manual); if you want to match one of those sometimes-special characters as literal character _in those situations_, those sometimes-special characters will also have to be escaped _in those situations_ by putting a `\` before it.
     * _Please note_: if you escape a normal character, it will sometimes _gain_ a special meaning; this is why so many of the syntax items listed in this section have a `\` before them.
 
 ##### Match by character code
@@ -589,7 +589,7 @@ Anchors match a zero-length position in the line, rather than a particular chara
 
 * `\Z` ⇒ Matches like `\z` with an optional sequence of newlines before it. This is equivalent to `(?=\v*\z)`, which departs from the traditional Perl meaning for this escape.
 
-* `\G` ⇒ This "Continuation Escape" matches the end of the previous match.  In **Find All** or **Replace All** circumstances, this will allow you to anchor your next match at the end of the previous match.  If it is the first match of a **Find All** or **Replace All**, and any time you use a single **Find Next** or **Replace**, the "end of previous match" is defined to be the start of the search area -- the beginning of the document, or the current cursor position, or the start of the highlighted text.
+* `\G` ⇒ This "Continuation Escape" matches the end of the previous match.  In **Find All** or **Replace All** circumstances, this will allow you to anchor your next match at the end of the previous match.  If it is the first match of a **Find All** or **Replace All**, and any time you use a single **Find Next** or **Replace**, the "end of previous match" is defined to be the start of the search area -- the beginning of the document, or the current caret position, or the start of the highlighted text.
 
 
 
@@ -770,7 +770,7 @@ These special groups consume no characters. Their successful matching counts, bu
 
     * NOTE: In the lookbehind assertions, _pattern_ has to be of fixed length, so that the regex engine knows where to test the assertion.  Similar constructs for  variable-length lookbehind include:
         - For variable-length lookbehind assertions from a limited set of constant data items, a construct such as `((?<=short)|(?<=longer))` is viable.  The individual lookbehinds still cannot include `+` or `*` or similar variable-length syntax.
-        - If your desired lookbehind is more complicated than that, you can use `\K` (see above): instead of `(?<=a.*b)MATCH`, which won't work, use `a.*b\KMATCH`.  The `\K` workaround will only work if the desired lookbehind is the first part of your match, because _everything_ before the `\K` is excluded from the final match. 
+        - If your desired lookbehind is more complicated than that, you can use `\K` (see above): instead of `(?<=a.*b)MATCH`, which won't work, use `a.*b\KMATCH`.  The `\K` workaround will only work if the desired lookbehind is the first part of your match, because _everything_ before the `\K` is excluded from the final match.
 
 ### Substitutions
 


### PR DESCRIPTION
Change nearly all instances of "cursor" to "caret", except where it is actually talking about the mouse cursor (when hovering over text or GUI location, or when right-clicking).  Any place that "cursor" remains, made it clear it was talking about the mouse cursor.  

(... and kept **`NPPM_GETFILENAMEATCURSOR`**, as that is the name of the message.)