### PR TITLE
clarify -z

### DIFF
--- a/content/docs/command-prompt.md
+++ b/content/docs/command-prompt.md
@@ -186,8 +186,8 @@ usage list.  These are intended for advanced usage or other special circumstance
   a command-line option when you try to print the file from the Explorer Context menu.
   Enabling this option allows Notepad++ to recognize that option, and convert it internally
   to the official `-quickPrint` option.
-* `-z`: Strips out any command line arguments found after this option. Its only intended and
-  supported use is for the [Notepad Replacement](../other-resources/#notepad-replacement)
+* `-z`: Causes Notepad++ to ignore the next command line argument token (single word, or phrase in quotes). The only intended and
+  supported use for this option is for the [Notepad Replacement](../other-resources/#notepad-replacement) syntax.
 
 ## Installer Options
 


### PR DESCRIPTION
The manual previously said `-z` option would strip out any command-line arguments after `-z`.  But "strip out" was imprecise (since they were technically still in the command line, just ignored).  And the original phrasing was based on the [comment in the code](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/3de506bf48c53c424ef1e52d623f1d949465102b/PowerEditor/src/winmain.cpp#L325) which strongly suggested it would ignore zero or more arguments after the `-z`, but experiments in multiple versions of Notepad++ (back to v7.7.1, which comes before a major rework in that function) showed that it historically has only actually made Notepad++ ignore a single token .

(I understand it's not critical, because -z should only be used for "Notepad Replacement" syntax.  But Alan likes nitpicking the documentation when he comes across slight behavioral differences, and I want it to be accurate.)