### PR TITLE
Update zipfile: no search bar

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Retrieve data from server
       working-directory: .
       run: |
-           cmd /c start hugo.exe server --minify --theme book
+           cmd /c start hugo.exe server --theme book
            $env:Path += ";C:\Program Files\WinHTTrack\"
            httrack.exe "http://127.0.0.1:1313/" -O "./httrack_output"
            Set-Location -Path httrack_output

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -25,6 +25,9 @@ jobs:
            httrack.exe "http://127.0.0.1:1313/" -O "./httrack_output"
            Set-Location -Path httrack_output
            Rename-Item -Path 127.0.0.1_1313 -NewName nppUserManual
+           Copy-Item "./nppUserManual/index.html" "./nppUserManual/index.unedited"
+           get-content "./nppUserManual/index.unedited" | %{$_ -replace 'id="book-search-input" maxlength="64" readonly','id="book-search-input" maxlength="64" readonly hidden'} | set-content "./nppUserManual/index.html"
+           Remove-Item "./nppUserManual/index.unedited"
 
     - name: Archive artifacts for hugo
       uses: actions/upload-artifact@v3

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -25,9 +25,18 @@ jobs:
            httrack.exe "http://127.0.0.1:1313/" -O "./httrack_output"
            Set-Location -Path httrack_output
            Rename-Item -Path 127.0.0.1_1313 -NewName nppUserManual
-           Copy-Item "./nppUserManual/index.html" "./nppUserManual/index.unedited"
-           get-content "./nppUserManual/index.unedited" | %{$_ -replace 'id="book-search-input" maxlength="64" readonly','id="book-search-input" maxlength="64" readonly hidden'} | %{$_ -replace 'href="http://localhost:1313/"','href="./index.html"'}  | %{$_ -replace 'href="http://localhost:1313/','href="'} | set-content "./nppUserManual/index.html"
-           Remove-Item "./nppUserManual/index.unedited"
+           Get-ChildItem -Recurse "./nppUserManual" -Filter index.html | Foreach-Object {
+               $orgname = $_.FullName
+               $tmpname = "$($orgname).unedited"
+               echo $tmpname
+               Copy-Item $orgname $tmpname
+               get-content $tmpname | 
+                    %{$_ -replace 'id="book-search-input" maxlength="64" readonly','id="book-search-input" maxlength="64" readonly hidden'} | 
+                    %{$_ -replace 'href="http://localhost:1313/"','href="./index.html"'} | 
+                    %{$_ -replace 'href="http://localhost:1313/','href="'} | 
+                    set-content $orgname
+               Remove-Item $tmpname
+           }
 
     - name: Archive artifacts for hugo
       uses: actions/upload-artifact@v3

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -26,7 +26,7 @@ jobs:
            Set-Location -Path httrack_output
            Rename-Item -Path 127.0.0.1_1313 -NewName nppUserManual
            Copy-Item "./nppUserManual/index.html" "./nppUserManual/index.unedited"
-           get-content "./nppUserManual/index.unedited" | %{$_ -replace 'id="book-search-input" maxlength="64" readonly','id="book-search-input" maxlength="64" readonly hidden'} | set-content "./nppUserManual/index.html"
+           get-content "./nppUserManual/index.unedited" | %{$_ -replace 'id="book-search-input" maxlength="64" readonly','id="book-search-input" maxlength="64" readonly hidden'} | %{$_ -replace 'href="http://localhost:1313/"','href="./index.html"'}  | %{$_ -replace 'href="http://localhost:1313/','href="'} | set-content "./nppUserManual/index.html"
            Remove-Item "./nppUserManual/index.unedited"
 
     - name: Archive artifacts for hugo

--- a/.github/workflows/onTag_zip_manual_as_asset.yml
+++ b/.github/workflows/onTag_zip_manual_as_asset.yml
@@ -23,11 +23,14 @@ jobs:
     - name: Convert hugo site to standandalone HTML
       working-directory: .
       run: |
-           cmd /c start hugo.exe server --minify --theme book
+           cmd /c start hugo.exe server --theme book
            $env:Path += ";C:\Program Files\WinHTTrack\"
            httrack.exe "http://127.0.0.1:1313/" -O "./httrack_output"
            Set-Location -Path httrack_output
            Rename-Item -Path 127.0.0.1_1313 -NewName nppUserManual
+           Copy-Item "./nppUserManual/index.html" "./nppUserManual/index.unedited"
+           get-content "./nppUserManual/index.unedited" | %{$_ -replace 'id="book-search-input" maxlength="64" readonly','id="book-search-input" maxlength="64" readonly hidden'} | set-content "./nppUserManual/index.html"
+           Remove-Item "./nppUserManual/index.unedited"
            Compress-Archive -Path nppUserManual -DestinationPath nppUserManual.zip
            Set-Location -Path ..
 

--- a/.github/workflows/onTag_zip_manual_as_asset.yml
+++ b/.github/workflows/onTag_zip_manual_as_asset.yml
@@ -28,9 +28,18 @@ jobs:
            httrack.exe "http://127.0.0.1:1313/" -O "./httrack_output"
            Set-Location -Path httrack_output
            Rename-Item -Path 127.0.0.1_1313 -NewName nppUserManual
-           Copy-Item "./nppUserManual/index.html" "./nppUserManual/index.unedited"
-           get-content "./nppUserManual/index.unedited" | %{$_ -replace 'id="book-search-input" maxlength="64" readonly','id="book-search-input" maxlength="64" readonly hidden'} | set-content "./nppUserManual/index.html"
-           Remove-Item "./nppUserManual/index.unedited"
+           Get-ChildItem -Recurse "./nppUserManual" -Filter index.html | Foreach-Object {
+               $orgname = $_.FullName
+               $tmpname = "$($orgname).unedited"
+               echo $tmpname
+               Copy-Item $orgname $tmpname
+               get-content $tmpname | 
+                    %{$_ -replace 'id="book-search-input" maxlength="64" readonly','id="book-search-input" maxlength="64" readonly hidden'} | 
+                    %{$_ -replace 'href="http://localhost:1313/"','href="./index.html"'} | 
+                    %{$_ -replace 'href="http://localhost:1313/','href="'} | 
+                    set-content $orgname
+               Remove-Item $tmpname
+           }
            Compress-Archive -Path nppUserManual -DestinationPath nppUserManual.zip
            Set-Location -Path ..
 


### PR DESCRIPTION
The CI and TAG actions now hide the search bar from the offline archive, because the search feature doesn't work right in offline mode.

While I was at it, also changed some links from localhost:1313 to index.html, so that the main "Notepad++ User Manual" link on every page goes _somewhere_ instead of a broken link.