### PR TITLE
Validating XML

### DIFF
--- a/content/docs/auto-completion.md
+++ b/content/docs/auto-completion.md
@@ -178,3 +178,7 @@ The simplest way to build a new file might be this:
 For case sensitive sorting, you can use Notepad++'s **Edit > Line Operations > Sort Lexicographically Ascending**, or any generic ASCII/ANSI sorter that sorts on the byte value of the characters. Simply put, this means the underscore character is between uppercase and lowercase letters.
 
 For case insensitive sorting, treat lowercase letters as uppercase, that is, subtract 32 from each lowercase byte value; this means the underscore must come both after uppercase and lowercase letters.  Unfortunately, Notepad++'s **Edit > Line Operations > Sort Lexicographically Ascending** does case-sensitive sorting, and will not work for this purpose.
+
+## Validating autoCompletion files
+
+If you are developing an autoCompletion file and would like to be able to validate that you have correct XML syntax while you are doing so, you can see the instructions in the [Notepad++ Community "Validating Config-File XML" FAQ](# "URL TBD").

--- a/content/docs/auto-completion.md
+++ b/content/docs/auto-completion.md
@@ -103,7 +103,7 @@ For keywords that are not functions, the `<KeyWord>` tag is autoclosing and only
 
 Then, for each overload of the function, an `<Overload>` element should be added, which specifies the behavior and the parameters of the function. A function must have at least one `<Overload>` or it will not be displayed as a calltip.  Multiple `<Overload>` elements allow there to be different sets of parameters for a given function.  The `retVal` attribute must be present and specifies the type of the return value, but the `descr` attribute is optional and describes the functions behavior, like a comment. You can add newlines in the description if you wish to do so. For each parameter the function takes, a `<Param>` element can be added. The `name` attribute must be present and specifies the type of the parameters and/or any name of the parameter.
 
-In the `<AutoComplete>` element you can add the `language` attribute, but it is not used by Notepad++; you can add it for completeness if you wish and can take any string you want.
+In the `<AutoComplete>` element you can add the `language` attribute, but it is not used by Notepad++; you can add it for completeness if you wish and can technically take any string you want, though standard practice among autoCompletion developers has been to put the official name of the language as the value (like the `C++` shown above).
 
 ### Auto-completion File Format
 

--- a/content/docs/config-files.md
+++ b/content/docs/config-files.md
@@ -436,3 +436,7 @@ You can have multiple icon set directories; to switch between icon sets, you jus
 - `session.xml`: Stores the current [session](../session/) information. Overwritten on every exit of Notepad++ if [**Settings > Preferences > Backup > Remember current session for next launch**](../preferences/#backup) is enabled. If you want sessions that you control, use **File > Save Session...** to save it; the file is safe to edit; and you can reload that session at any time using **File > Load Session...**. This config file _must_ go in the Notepad++ installation folder; it will not be recognized in the `%AppData%\Notepad++` hierarchy or in the cloud settings folder.
 
 - `userDefineLang.xml` and `userDefineLangs\*.xml`: Configuration location for the [**User Defined Languages**](../user-defined-language-system/) feature.
+
+## Validating Config-File XML
+
+If you are developing a config file by editing the raw XML file and would like to be able to validate that you have correct XML syntax while you are doing so, you can see the instructions in the [Notepad++ Community "Validating Config-File XML" FAQ](# "URL TBD").

--- a/content/docs/config-files.md
+++ b/content/docs/config-files.md
@@ -439,4 +439,4 @@ You can have multiple icon set directories; to switch between icon sets, you jus
 
 ## Validating Config-File XML
 
-If you are developing a config file by editing the raw XML file and would like to be able to validate that you have correct XML syntax while you are doing so, you can see the instructions in the [Notepad++ Community "Validating Config-File XML" FAQ](# "URL TBD").
+If you are developing a config file by editing the raw XML file and would like to be able to validate that you have correct XML syntax while you are doing so, you can see the instructions in the [Notepad++ Community "Validating Config-File XML" FAQ](https://community.notepad-plus-plus.org/topic/24136/faq-desk-validating-config-file-xml "Community Forum FAQ Desk: Validating Config-File XML).

--- a/content/docs/function-list.md
+++ b/content/docs/function-list.md
@@ -80,7 +80,7 @@ If you do not like the results of the default Function List parser that ships wi
 
 ## Validating Function List defintion files
 
-If you are developing a Function List definition file and would like to be able to validate that you have correct XML syntax while you are doing so, you can see the instructions in the [Notepad++ Community "Validating Config-File XML" FAQ](# "URL TBD").
+If you are developing a Function List definition file and would like to be able to validate that you have correct XML syntax while you are doing so, you can see the instructions in the [Notepad++ Community "Validating Config-File XML" FAQ](https://community.notepad-plus-plus.org/topic/24136/faq-desk-validating-config-file-xml).
 
 ## Contribute your new or enhanced parser rule to the Notepad++ codebase
 

--- a/content/docs/function-list.md
+++ b/content/docs/function-list.md
@@ -78,6 +78,10 @@ Once you finish defining your parser, save and name the file as the language nam
 ## Use your own personal function list definition for a built-in language
 If you do not like the results of the default Function List parser that ships with Notepad++ for a particular language, feel free to write your parser rule then save with a unique filename (like `my_languagename.xml`).  (_Note_: if you edit the existing `languagename.xml`, the next update may erase your changes.)  Use your [overrideMap.xml](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/functionList/overrideMap.xml) in the functionList directory to override the default mapping of functionList parser rule files, or to add a mapping to new UDL parser rule files, as described in the [function list config files](../config-files/#function-list) section of the manual. 
 
+## Validating Function List defintion files
+
+If you are developing a Function List definition file and would like to be able to validate that you have correct XML syntax while you are doing so, you can see the instructions in the [Notepad++ Community "Validating Config-File XML" FAQ](# "URL TBD").
+
 ## Contribute your new or enhanced parser rule to the Notepad++ codebase
 
 If you have added or updated the parser definition file for one of Notepad++'s built-in languages, you are welcome to contribute your file to the Notepad++ codebase by creating "Pull Request" (also called a "PR") on the [Notepad++ GitHub page](https://github.com/notepad-plus-plus/notepad-plus-plus).  (A "Pull Request" is just the GitHub mechanism for requesting that code you write be added to a project.)

--- a/content/docs/user-defined-language-system.md
+++ b/content/docs/user-defined-language-system.md
@@ -140,3 +140,7 @@ The `<WordsStyle>` `colorStyle` attribute decides whether to use the defined col
 * Set `colorStyle="2"`: this style will inherit the foreground color from the Default style, and use the `bgColor` value as the background color (equivalent to right-clicking the foreground color in the UDL styler dialog box)
 * Set `colorStyle="1"`: this style will inherit the background color from the Default style, and use the `fgColor` value as the foreground color (equivalent to right-clicking the background color in the UDL styler dialog box)
 * Set `colorStyle="0"`: this style will inherit both the foreground and background colors from the Default style (equivalent to right-clicking both the foreground and background colors in the UDL styler dialog box)
+
+### Validating User Defined Language defintion files
+
+If you are developing a User Defined Definition by editing the raw XML file (instead of just using the UDL GUI interface) and would like to be able to validate that you have correct XML syntax while you are doing so, you can see the instructions in the [Notepad++ Community "Validating Config-File XML" FAQ](# "URL TBD").

--- a/content/docs/user-defined-language-system.md
+++ b/content/docs/user-defined-language-system.md
@@ -143,4 +143,4 @@ The `<WordsStyle>` `colorStyle` attribute decides whether to use the defined col
 
 ### Validating User Defined Language defintion files
 
-If you are developing a User Defined Definition by editing the raw XML file (instead of just using the UDL GUI interface) and would like to be able to validate that you have correct XML syntax while you are doing so, you can see the instructions in the [Notepad++ Community "Validating Config-File XML" FAQ](# "URL TBD").
+If you are developing a User Defined Definition by editing the raw XML file (instead of just using the UDL GUI interface) and would like to be able to validate that you have correct XML syntax while you are doing so, you can see the instructions in the [Notepad++ Community "Validating Config-File XML" FAQ](https://community.notepad-plus-plus.org/topic/24136/faq-desk-validating-config-file-xml).


### PR DESCRIPTION
Quick notes on validating config-file XML, with a link to the detailed FAQ.

per https://community.notepad-plus-plus.org/topic/24092/how-to-add-autocomplete-schema-to-npp-distro and https://github.com/notepad-plus-plus/userDefinedLanguages/issues/154 => https://community.notepad-plus-plus.org/topic/24136/faq-desk-validating-config-file-xml