### PR TITLE
update Supported Programming Languages table 

### DIFF
--- a/content/docs/programing-languages.md
+++ b/content/docs/programing-languages.md
@@ -5,27 +5,28 @@ weight: 10
 
 ## Supported Programming Languages
 
-Almost 80 Programming Languages are supported by Notepad++:
+Around 90 Programming Languages are supported by Notepad++:
 
-|              |                    |                        |               |               |
-|--------------|--------------------|------------------------|---------------|---------------|
-| ActionScript | Ada                | ASN.1                  | ASP           | Assembly      |
-| AutoIt       | AviSynth scripts   | BaanC                  | batch files   | Blitz Basic   |
-| C            | C#                 | C++                    | Caml          | CMake         |
-| Cobol        | CoffeeScript       | Csound                 | CSS           | D             |
-| Diff         | Erlang             | escript                | Forth         | Fortran       |
-| FreeBASIC    | Gui4Cli            | Haskell                | HTML          | INI files     |
-| Intel HEX    | Inno Setup scripts | Java                   | JavaScript    | JSON          |
-| JSP          | KiXtart            | LaTeX                  | LISP          | Lua           |
-| Makefile     | Matlab             | MMIX                   | Nim           | nnCron        |
-| NSIS scripts | Objective-C        | OScript                | Pascal        | Perl          |
-| PHP          | PostScript         | PowerShell             | PureBasic     | Python        |
-| R            | Rebol              | Registry script (.reg) | Resource file | Ruby          |
-| Rust         | Scheme             | Shell script           | Smalltalk     | SPICE         |
-| SQL          | Swift              | S-Record               | Tcl           | Tektronix HEX |
-| TeX          | txt2tags           | Visual Basic           | Visual Prolog | VHDL          |
-| Verilog      | XML                | YAML                   |               |               |
-
+|                       |                        |                        |                        |                       |
+|-----------------------|------------------------|------------------------|------------------------|-----------------------|
+|ActionScript           | Ada                    | ASN.1                  | ASP                    | Assembly              |
+|AutoIt                 | AviSynth               | BaanC                  | Batch                  | BlitzBasic            |
+|C                      | C#                     | C++                    | CAML                   | CMake                 |
+|COBOL                  | CoffeeScript           | Csound                 | CSS                    | D                     |
+|Diff                   | Erlang                 | ESCRIPT                | Forth                  | Fortran fixed form    |
+|Fortran free form      | FreeBasic              | GDScript               | Gui4Cli                | Haskell               |
+|Hollywood              | HTML                   | ini                    | Inno Setup             | Intel HEX             |
+|Internal Search        | Java                   | JavaScript             | JavaScript             | json                  |
+|json5                  | JSP                    | KiXtart                | LaTeX                  | Lisp                  |
+|Lua                    | Makefile               | MATLAB                 | MMIXAL                 | mssql                 |
+|NFO                    | Nim                    | Nncrontab              | NSIS                   | Objective-C           |
+|OScript                | Pascal                 | Perl                   | PHP                    | PostScript            |
+|PowerShell             | Properties file        | PureBasic              | Python                 | R                     |
+|RC                     | REBOL                  | registry               | Ruby                   | Rust                  |
+|S-Record               | Scheme                 | Shell                  | Smalltalk              | Spice                 |
+|SQL                    | Swift                  | TCL                    | Tektronix extended HEX | TeX                   |
+|txt2tags               | TypeScript             | Verilog                | VHDL                   | Visual Basic          |
+|Visual Prolog          | XML                    | YAML                   |                        |                       |
 
 For these languages, Notepad++ supports [syntax highlighting](../preferences/#style-configurator) (customizable),
 syntax folding, [auto-completion](../auto-completion/) (customizable),
@@ -35,9 +36,10 @@ If your beloved language is not in the list above, you can define it yourself ea
 [User Defined Languages System](../user-defined-language-system/).  If that doesn't meet your needs,
 you could write (or have someone else write) a [lexer plugin](../plugins/#building-a-lexer-plugin).
 
-Please note that in Notepad++ v8.3 and newer, Notepad++ will no longer perform syntax highlighting
-\on files that are over 200MB -- this prevents extreme performance slowdown caused by trying to
-syntax highlight extremely large files.
+Please note that in Notepad++ v8.3 and newer, Notepad++ has a feature will no longer perform syntax highlighting
+on files that are over 200MB -- this prevents extreme performance slowdown caused by trying to
+syntax highlight extremely large files.  This threshold is configurable in
+[Settings > Preferences > Performance](../preferences/#performance) (starting in v8.4.7).
 
 ## Language Detection Priority
 


### PR DESCRIPTION
... to match the 88 that are available in v8.5.2

------

Instructions for the next time I want to do this: use the `_shortName` column from the `LanguageNameInfo ScintillaEditView::_langNameInfoArray` variable in [ScintillaEditView.cpp](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp#L65-L160):
- copy the table
- delete the rows for `normal`, `udf`, and `ext`, and any headers or footers or comments that were copied
- **FIND** = `(?-s)^\h*{TEXT.*?TEXT\("(.*?)"\).*$`
  **REPLACE** = `$1                                      |`
  **REPLACE ALL**
- use column-selection to select a narrow column between the rightmost language name character (probably `Tektronix extended HEX`) and the `|`, and use `Ctrl+DEL` to delete-to-start-of-word to narrow it down to a straight vertical column of `|`
- **Edit > Line Operations > Sort Lines Lex. Ascending Ignoring Case**
- add 0-4 empty fields (just spaces and `|`) until the total number of lines is a multiple of 5 (not counting a blank line at the end of the file)
- **FIND** = `(?-s)^(.*)\R(.*)\R(.*)\R(.*)\R(.*)`
  **REPLACE** = `| $1 $2 $3 $4 $5`
  **REPLACE ALL**
