### PR TITLE
minor amendments 3

### DIFF
--- a/content/docs/searching.md
+++ b/content/docs/searching.md
@@ -192,7 +192,7 @@ Bookmarks, whether visible or not, have a menu that can control and navigate Boo
 
 ### Search results window
 
-After running one or more **Find All in ...** commands, a new **Search results** window appears, and within it is placed a **Search results** tab.  The **Search results** window may be opened and/or given input focus by using the menu command **Search > Search Results Window** or the F7 keyboard shortcut.  *Note:*  That menu command will seem to not do anything if there haven't been any **Find All in ...** commands run since Notepad++ was opened.
+After running one or more **Find All in ...** commands, a new **Search results** window appears, and within it is placed a **Search results** tab.  The **Search results** window may be opened and/or given input focus by using the menu command **Search > Search Results Window** or the `F7` keyboard shortcut.  *Note:*  That menu command will seem to not do anything if there haven't been any **Find All in ...** commands run since Notepad++ was opened.
 
 *Definition:*  **Find All in ...** commands include:
 
@@ -207,15 +207,16 @@ The **Search results** window by default appears docked at the bottom of the Not
 
 From **Find All in ...** searches, three types of sections are added to the **Search results** window.  First is a line describing what was searched for, how many total matches (known as "hits") occurred (this is also shown in the title bar for the window, for the most recently-occurring search), and how many files had matches.  Second is a line that shows the filename with the matches and the count of matches for that file (this type will be repeated if the search found multiple files with matches).  Last comes the details about the matches found, including line number and the line contents with the matched text emphasized.  The default emphasis is red text on a yellow background, but this may be changed in the Style Configurator's "Search result" Language area.
 
-When Notepad++ populates the **Search results** window, it does so using one line for each match found by the search.  Note that this can and often does end with the same source file line being repeated multiple times in the output.  An example of this would be if you are searching for "the" in the line of text that reads "Now is the time for all good men to come to the aid of their country"; the **Search results** window would list the line twice, once with the word "the" called out in red text with a yellow background, and a second time with "the" in "their" similarly emphasized.
+When Notepad++ populates the **Search results** window, it does so using one line for each match found by the search.  Note that this can and often does end with the same source file line being repeated multiple times in the output.  An example of this would be if you are searching for "the" in the line of text that reads "Now is the time for all good men to come to the aid of their country"; the **Search results** window would list the line three times, twice with each word "the" called out in red text with a yellow background, and a third time with "the" in "their" similarly emphasized.
+However, multiple findings of the same search term may be collapsed into one search result by checking the option [**Settings > Preferences > Searching > ☐ Search Result window: show only one entry per found line**](../preferences/#searching).
 
 When the **Search results** window has input focus, the currently active line has a different background color, much like how the main editor window does by default.  Unlike the main editor window, where the current-line background feature may be turned off, the **Search results** window always has a background highlight for its active line.
 
-Use the up and down arrows to navigate within the **Search results** window when it has input focus.  Double-clicking with the mouse or hitting ENTER when input focus is on a specific match will move the editor window to that match and cause its text to be selected.
+Use the up and down arrows to navigate within the **Search results** window when it has input focus.  Double-clicking with the mouse or hitting `ENTER` when input focus is on a specific match will move the editor window to that match and cause its text to be selected.
 
-Other ways to navigate back to an editor window via the **Search results** window matches include the **Search** menu items **Next Search Result** (keyboard: F4) and **Previous Search Result** (keyboard: Shift+F4).  These can be invoked regardless of where input focus is in Notepad++.
+Other ways to navigate back to an editor window via the **Search results** window matches include the **Search** menu items **Next Search Result** (keyboard: `F4`) and **Previous Search Result** (keyboard: `Shift+F4`).  These can be invoked regardless of where input focus is in Notepad++.
 
-The *Delete* key can be used to delete individual results, file matches or whole search matches in the **Search results** window, depending on which type of line is active when the key is pressed.  As the result history is hierarchical, that is, tree-like, pressing *Delete* when in a higher-level element of the tree removes that whole branch.  Thus:
+The `Delete` key can be used to delete individual results, file matches or whole search matches in the **Search results** window, depending on which type of line is active when the key is pressed.  As the result history is hierarchical, that is, tree-like, pressing `Delete` when in a higher-level element of the tree removes that whole branch.  Thus:
 
 |*Pressing Delete when **Search results** active line starts with...*| *What is removed*                                                                              |
 |-----------------------------------------------------------------|------------------------------------------------------------------------------------------------|
@@ -223,82 +224,77 @@ The *Delete* key can be used to delete individual results, file matches or whole
 |a pathname                                                       | that pathname line and all "Line" lines under it                                                |
 |the text: "Line"                                                 | only that line                                                                                 |
 
-Multiple searches will be listed under separate headers, which are "foldable", so you can hide or unhide results from previous searches.  When you run a new search, previous searches are folded closed.
+Multiple searches are listed under separate headers, which are "foldable", so you can hide or unhide results from previous searches.  When you run a new search, previous searches are folded closed.
 
-If the source file lines are judged by Notepad++ to be too long when they are copied to be placed in the **Search results** window, they will be truncated and **...** will be added at the end.  In this case, matched text occurring in the line after the **...** position will not be emphasized.  However, using a method to return to the editor window (e.g. pressing Enter) will result in the correct selection of matching text there.  The length limit is 1024 characters; this includes the match line number information and other formatting.
+If the source file lines are judged by Notepad++ to be too long when they are copied to be placed in the **Search results** window, they are truncated and **...** is added at the end.  In this case, matched text occurring in the line after the **...** position isn't emphasized.  However, using a method to return to the editor window (e.g. pressing `Enter`) results in the correct selection of matching text there.  The length limit is 1024 characters; this includes the match line number information and other formatting.
 
-If a search is conducted such that a match which spans two or more lines occurs, only the contents of the *FIRST* line of that match will be copied into the **Search results** window.  However, using a method to return to the editor window (e.g. pressing Enter) will result in the correct selection of multi-line matching text there.
+If a search is conducted such that a match which spans two or more lines occurs, only the contents of the first line of that match is copied into the **Search results** window.  However, using a method to return to the editor window (e.g. pressing `Enter`) results in the correct selection of multi-line matching text there.
 
-#### *RightClick* commands in the client area of a **Search results** window's tab
+#### `RightClick` commands in the client area of a **Search results** window's tab
 
 ##### Copying text from the **Search results** window
 
-There are two ways to copy exact text from the **Search results** window:  Make sure input focus is in the **Search results** window by selecting some text and use the keyboard's *Ctrl+c*, or use the mouse's *RightClick* to invoke the context menu and select **Copy**.  These two copy mechanisms produce identical results.  Another choice is to use the context menu's **Copy Selected Line(s)** command; this type of copy can be thought of as a "Copy Special".  It copies the text of ENTIRE LINES from the results, WITHOUT any search information (called "metadata") being included in what is copied.
+There are two ways to copy exact text from the **Search results** window:  Make sure input focus is in the **Search results** window by selecting some text and press `Ctrl+C`, or `RightClick` to invoke the context menu and select **Copy**.  These two copy mechanisms produce identical results.  Another choice is to use the context menu's **Copy Selected Line(s)** command; this copies entire lines from the results, excluding search information (called "metadata").
 
-Here's a more detailed description of what happens for *RightClick* > **Copy Selected Line(s)**:
+More precisely:
 
-First, if the user makes a selection of text in the **Search results** window and copies it this way, only the lines of text touched (even partially) by the selection are part of the copy.  All other text with information about the search (pathname, line number, etc.) is *not* copied, even if part of the selection.  Secondly, if there is no active selection when the *RightClick* > **Copy Selected Line(s)** is invoked, results depend upon what exactly is under the mouse cursor during the *RightClick*:
-
-| *RightClick* item     | What gets copied when *RightClick* > **Copy Selected Line(s)** is run |
+| `RightClick` item     | What gets copied when **`RightClick` > Copy Selected Line(s)** is run |
 |-----------------------|-----------------------------------------------------------------------------------------------------|
-|a line with line # info|the entire line of the *RightClick* but without line number text                                     |
+|a line with line # info|the entire line of the `RightClick` but without line number text                                     |
 |a pathname header line |all the lines for that single file without pathname or line number text                              |
 |a "search" header line |all the lines for that search (1 or more files) without search header, pathname or line number text  |
 
-*Tip*:  It is possible to select and copy a rectangular selection of data from the **Search results** window.  This is done using the usual Shift+Alt+arrow keys or by holding Alt+LeftClick and dragging with the mouse.  This is really only practical when using the *Ctrl+c* method of copying; *RightClick* > **Copy Selected Line(s)** only copies entire lines, and this copy will only copy the single full line at the top/bottom of the column block.
+*Tip*:  It is possible to select and copy a rectangular selection of data from the **Search results** window.  This is done using the usual `Shift+Alt+arrow keys` or by holding `Alt+LeftClick` and dragging with the mouse.  This is really only practical when using the `Ctrl+C` method of copying; **`RightClick` > Copy Selected Line(s)** doesn't work this way.
 
-There is a capability to copy a list of the files that contained hits from past searches (v8.0.0 and later).  The **Copy Pathname(s)** context menu command will copy to the clipboard the full pathnames of all files appearing in **Search results**.
+There is a capability to copy the list of files containing hits from past searches (v8.0.0 and later).  The **Copy Pathname(s)** context menu command copies to the clipboard the full pathnames of all files appearing in **Search results**.
 
 ##### Other commands
 
 There are some commands that don't need a lot of explanation; these are:
 
-* **Collapse all**
-* **Uncollapse all**
+* **Fold all**
+* **Unfold all**
 * **Select all**
 * **Clear all**
 * **Open all**
 
-The **Search results** window/tab accumulates results from every **Find All in ...** search the user does; the results from old searches remain until the user removes them.  Individual results can be deleted with the *Delete* key, or all previous results can be deleted by invoking **Clear all**.  Stale results can be removed to reduce visual clutter, or when it is desired that a follow-on action should not be affected by old results.  An example of this would be the **Open all** command which opens *all* files listed in the **Search results** tab that have previously had hits.  If the search history in **Search results** is really long, it may not be desirable to open all files listed there, so using **Clear all** before doing some new searches (with the intent to **Open all** afterwards) may be the thing to do.
+The **Search results** window/tab accumulates results from every **Find All in ...** search the user does; the results from old searches remain until the user removes them.  Individual results can be deleted with the `Delete` key, or all previous results can be deleted by invoking **Clear all**.  Stale results can be removed to reduce visual clutter, or when it is desired that a follow-on action should not be affected by old results.  An example of this would be the **Open all** command which opens *all* files listed in the **Search results** tab that have previously had hits.  If the search history in **Search results** is really long, it may not be desirable to open all files listed there, so using **Clear all** before doing some new searches with the intent to **Open all** afterwards may be the thing to do.
 
-The **Select all** command is self-explanatory:  *ALL* text in the **Search results** tab will be selected
+The **Select all** command is self-explanatory:  All text in the **Search results** tab is selected.
 
-The contents of the **Search results** tab are in the form of a tree.  When Notepad++ adds to the result history, it does so in an uncollapsed way, that is, the user can see all of the information from the recently-added search.  However, before adding new results, Notepad++ will collapse all previous result data; perhaps it is deciding that the most-recent search is the most important?
+The contents of the **Search results** tab are in the form of a tree.  When Notepad++ adds to the result history, the user can see all of the information from the recently-added search.  However, before adding new results, Notepad++ will fold all previous result data.
 
-The user can collapse/uncollapse "branches" of this tree.  To collapse, click with the mouse on the little box symbol with an interior `-`, found to the left of each line.  After doing so, that part of the tree will be collapsed (removed from view) and the first line of the branch (remaining visible) will then show a `+` in the box symbol.  To uncollapse an individual item that has previously been collapsed (either by the user or by Notepad++'s automatic mechanism), simply click the box symbol with the `+`.  That branch will then be expanded and again shown.
+The user can fold/unfold "branches" of this tree.  To fold, click with the mouse on the little box symbol with an interior `-`, found to the left of each line.  After doing so, that part of the tree will be folded (removed from view) and the first line of the branch (remaining visible) will then show a `+` in the box symbol.  To unfold an individual item that has previously been folded (either by the user or by Notepad++'s automatic mechanism), simply click the box symbol with the `+`.  That branch will then be expanded and shown again.
 
-The **Collapse all** and **Uncollapse all** commands perform the corresponding actions on *ALL* elements of the entire result history in the **Search results** window at once.  Perhaps a better name for **Uncollapse all** would have been the more-conventional "Expand all"?
+The **Fold all** and **Unfold all** commands perform the corresponding actions on all elements of the entire result history in the **Search results** window at once.
 
 ##### Searching in previously-found results (secondary searching)
 
-Perhaps you have done a search and your results are in a tab in the **Search results** window.  Now you'd like to conduct a search but with a scope of only the files that have previous matches.  Or maybe you want to look only in the *lines* matched by previous searches, not only the matched files, tightening the search criteria even more.  Can you do this sort of second-level searching with Notepad++?  Yes, by *RightClick*ing the **Search results** window client area and selecting **Find in these search results...**.
+Assume, you have done a search and your results are in a tab in the **Search results** window.  Now you'd like to conduct a search but with a scope of only the files that have previous matches.  Or maybe you want to look only in the *lines* matched by previous searches, not only the matched files, tightening the search criteria even more.  Can you do this sort of second-level searching with Notepad++?  Yes, by `RightClick`ing the **Search results** window client area and selecting **Find in these search results...**.
 
-Selecting **Find in these search results...** will cause a window to pop up, and this window looks much like the standard **Find** window, but is stripped down a bit.  Once you input your search parameters and choose **Find All**, a *new* **Search results** tab will open (in the **Search results** window) with the results of the "refined" search.
+Selecting **Find in these search results...** will cause a window to pop up, which looks much like the standard **Find** window, but stripped down a bit.  Once you input your search parameters and choose **Find All**, a *new* **Search results** tab will open (in the **Search results** window) with the results of the "refined" search.
 
 The popup window has a parameter not available in the searches described earlier:  **☐ Search only in found lines**.  Checking this box limits the search to lines that appear in matched files in the parent **Search results** window.  Unchecking the box will cause the new search to examine previously matched files in their entirety.  When a search has been limited to previously-found lines, its results will indicate this by using this type of output:  `Search "___" (__ hits in __ files - Line Filter Mode: only display the filtered results)` as opposed to the normally seen:  `Search "___" (__ hits in __ files)`
 
-*Tip:*  Use the *RightClick* option **Clear all** to limit the scope of these types of searches (before invoking the secondary search!) -- remember: a **Find in these search results...** search will look in files matched by ALL previous searches whose results are still present in the parent **Search results** tab.
+*Tip:*  Use the `RightClick` option **Clear all** to limit the scope of these types of searches (before invoking the secondary search!) -- remember: a **Find in these search results...** search will look in files matched by *all* previous searches whose results are still present in the parent **Search results** tab.
 
-*Tip:*  Since the newly opened **Search results** window also has a *RightClick* menu, you may do another **Find in these search results...** based upon the new results, focusing your search for some bit of data even more.  This type of refinement may be repeated as much as desired.  [Note that the title bar of the window does *not* show the hit count of the currently active tab, but rather shows the hit count of the *first* **Search results** tab of the window.]
+*Tip:*  Since the newly opened **Search results** window also has a `RightClick` menu, you may do another **Find in these search results...** based upon the new results, focusing your search for some bit of data even more.  This type of refinement may be repeated as often as desired.  [Note that the title bar of the window does *not* show the hit count of the currently active tab, but rather shows the hit count of the *first* **Search results** tab of the window.]
 
 *Note:*  The commands that switch input focus to the **Search results** window always activate the *first* **Search results** tab, not any additional **Search results** tabs that may have been created.
 
-*Note:*  The contents of the **Search results** window are discarded upon Notepad++ shutdown.  If there is data of importance there it should be copied, using one of the methods above, and saved in a more-permanent location.
+*Note:*  The contents of the **Search results** window are discarded upon Notepad++ shutdown.  If it contains data of importance, it should be copied using one of the methods above, and saved in a more-permanent location.
 
 ##### Search results configuration options
 
-There are currently two ways to configure the **Search results** window behavior, both located in the mouse's *RightClick* context menu:
+There are currently two ways to configure the **Search results** window behavior, both located in the `RightClick` context menu:
 
 * **Word wrap long lines**
 * **Purge for every search**
 
-These are checkmarkable menu items; invoke the menu item once to turn the feature on (checkmark will appear on the menu) and run it again to turn it off (checkmark no longer appears). These configuration settings are remembered by Notepad++ until their states are again changed by the user.
+When **Word wrap long lines** is turned on (checked), the **Search results** window text wraps at the right edge, and is continued on the next visible line.  With the feature off, the window has a horizontal scrollbar, so that the rightmost text on long lines may be scrolled into the user's view.
 
-When **Word wrap long lines** is turned on (checked), the **Search results** window text will wrap at the right edge, and be continued on the next visible line.  With the feature off, the window will have a horizontal scrollbar so that the rightmost text on long lines may be scrolled into the user's view.
-
-By default, the **Search results** window accumulates all of your prior **Find All in ...** type searches.  When a new search is executed, old results get collapsed so that only the most-recent results are fully visible at the top of the window.  The old searches remain toward the bottom of the window for possible future reference by expanding them. One use for retaining results from prior searches is to do several different searches, and then execute **Open All** command from the window's right-click context menu -- this will open all files hit by any previous series of possibly disparate searches.
-
-To some users these older results accumulating are an annoyance -- their data may become out of date quickly with changes to files -- so Notepad++ supports a setting that, after turned on, removes any old search data from the window before populating it with new.  To set or clear this setting, right-click anywhere in the Search results window, then click on the **Purge for every search** entry to change that setting: there will be a checkmark to indicate it's already on, and no checkmark to indicate it's off. _Note_: clicking this option doesn't immediately purge the old results; instead, searches made subsequent to enabling this option will purge the old results.
+To some users older search results accumulating are an annoyance, so Notepad++ supports a setting that, after turned on, removes any old search results from the window before populating it with new ones.  To set or clear this setting, right-click anywhere in the Search results window, then click on the **Purge for every search** entry to change that setting: There will be a checkmark to indicate it's already on, and no checkmark to indicate it's off.
+_Note_: Clicking this option doesn't immediately purge the old results; instead, searches made subsequent to enabling this option will purge the old results.
 
 ## Dialog-free search/mark actions
 


### PR DESCRIPTION
updating searching.md up to '## Dialog-free search/mark actions' (lines 194-299)

changes:
- `Code block format` `inputs`
- Correct search results example
- Add link to searching preferences
- Use present tense instead of future in writing
- Remove unnecessary CAPS highlighting
- Improve wording
- Delete redundant paragraphs
- Use 'fold' instead of 'collapse' as this is the current Notepad++ term
- Remove questions expressing uncertainty as to the intentions of the Notepad++ creators by an editor writing the manual