### PR TITLE
Move/Clone updates

### DIFF
--- a/content/docs/editing.md
+++ b/content/docs/editing.md
@@ -83,7 +83,7 @@ The cloned document is the same document as its original one, but with the separ
 
 ![](../images/clonedDoc.gif)
 
-You can find more on cloning to other views or instances in the [Views > Move / Clone](../views/move-clone) section, and more on manipulating tabs through the tab bar in [Other Resources > Tabs](../other-resources/#tabs).
+You can find more on cloning to other views or instances in the [Views > Move / Clone](../views/#move-clone) section, and more on manipulating tabs through the tab bar in [Other Resources > Tabs](../other-resources/#tabs).
 
 ## Character Panel
 

--- a/content/docs/editing.md
+++ b/content/docs/editing.md
@@ -75,11 +75,15 @@ Once you've got 2 views, you can move files between 2 views by drag-and-dropping
 
 ![](../images/move2view.gif)
 
+You can find more on moving to other views or instances in the [Views > Move / Clone](../views/move-clone) section, and more on manipulating tabs through the tab bar in [Other Resources > Tabs](../other-resources/#tabs).
+
 ## Clone Document
 Drag and drop any tab that you want to clone (or right click on the tab) then choose "Clone to Other View" command from the popup context menu.
 The cloned document is the same document as its original one, but with the separated views.
 
 ![](../images/clonedDoc.gif)
+
+You can find more on cloning to other views or instances in the [Views > Move / Clone](../views/move-clone) section, and more on manipulating tabs through the tab bar in [Other Resources > Tabs](../other-resources/#tabs).
 
 ## Character Panel
 

--- a/content/docs/editing.md
+++ b/content/docs/editing.md
@@ -75,7 +75,7 @@ Once you've got 2 views, you can move files between 2 views by drag-and-dropping
 
 ![](../images/move2view.gif)
 
-You can find more on moving to other views or instances in the [Views > Move / Clone](../views/move-clone) section, and more on manipulating tabs through the tab bar in [Other Resources > Tabs](../other-resources/#tabs).
+You can find more on moving to other views or instances in the [Views > Move / Clone](../views/#move-clone) section, and more on manipulating tabs through the tab bar in [Other Resources > Tabs](../other-resources/#tabs).
 
 ## Clone Document
 Drag and drop any tab that you want to clone (or right click on the tab) then choose "Clone to Other View" command from the popup context menu.

--- a/content/docs/other-resources.md
+++ b/content/docs/other-resources.md
@@ -81,62 +81,62 @@ Windows 10 and Windows 11 have a "restartable apps" feature (**Windows Start But
   ![tabNavMoveRtLft](../images/tabNavMoveRtLft.gif)
 
 - To move a tab from one View to the other, you can use the techniques described in the [Editing > Dual View](../editing/#dual-view) section or [Views > Move / Clone](../views/#move-clone) section, including:
-  1. Use the menus: **View > Move/Clone Current Document > Move to Other View**
-  2. Right Click on the tab's title and select **Move to Other View**
-  3. Drag the tab's title into the editing pane for that same tab and select **Move to Other View**
-  4. If the other View is already visible, drag the tab's title into the editing pane of the other View, and it will move
+  1. Use the menus: **View > Move/Clone Current Document > Move to Other View**.
+  2. Right Click on the tab's title and select **Move to Other View**.
+  3. Drag the tab's title into the editing pane for that same tab and select **Move to Other View**.
+  4. If the other View is already visible, drag the tab's title into the editing pane of the other View, and it will move.
   ![move2view](../images/move2view.gif)
 
 - To clone a tab from one View into the other, you can use the techniques described in the [Editing > Clone Document](../editing/#dual-view) or [Views > Move / Clone](../views/#move-clone) section section, including:
-  1. Use the menus: **View > Move/Clone Current Document > Clone to Other View**
-  2. Right Click on the tab's title and select **Clone to Other View**
-  3. Drag the tab's title into the editing pane for that same tab and select **Clone to Other View**
+  1. Use the menus: **View > Move/Clone Current Document > Clone to Other View**.
+  2. Right Click on the tab's title and select **Clone to Other View**.
+  3. Drag the tab's title into the editing pane for that same tab and select **Clone to Other View**.
   ![clonedDoc](../images/clonedDoc.gif)
 
 - To create a new file tab using the tab bar:
-  1. If there is empty area to the right of the last tab in the tab bar, double click there and a new tab will be created
+  1. If there is empty area to the right of the last tab in the tab bar, double click there and a new tab will be created.
   ![tabNavNewDoubleClick](../images/tabNavNewDoubleClick.gif)
 
 - To close a tab using the tab bar:
-  1. If **Settings > Preferences > General > Tab Bar > Show close button on each tab** is checked, you can click the red ☒ on that tab to close that tab
-  2. If **Settings > Preferences > General > Tab Bar > Double click to close document** is checked, you can double-click the tab's title to close that tab
+  1. If **Settings > Preferences > General > Tab Bar > Show close button on each tab** is checked, you can click the red ☒ on that tab to close that tab.
+  2. If **Settings > Preferences > General > Tab Bar > Double click to close document** is checked, you can double-click the tab's title to close that tab.
   ![tabNavCloseXDblClick](../images/tabNavCloseXDblClick.gif)
 
 #### Tab Bar Right Click Menu
 
 When you right click on the title for a tab, you get a context menu for manipulating that tab.
 
-- `Close`: closes this file's tab
+- `Close`: Closes this file's tab.
 - `Close Mutiple Tabs >`:
-  - `Close All But This`: Closes all files except this file
-  - `Close All to the Left`: Closes all files that are to the right of this file on the tab bar
-  - `Close All to the Right`: Closes all files that are to the left of this file on the tab bar
-  - `Close All Unchanged`: Closes all files that do not have unsaved changes (leaves only files that have unsaved changes)
-- `Save`: Saves the file (disabled/greyed out if there are no unsaved changes)
-- `Save As`: Allows you to save the current file under a new name
+  - `Close All But This`: Closes all files except this file.
+  - `Close All to the Left`: Closes all files that are to the right of this file on the tab bar.
+  - `Close All to the Right`: Closes all files that are to the left of this file on the tab bar.
+  - `Close All Unchanged`: Closes all files that do not have unsaved changes (leaves only files that have unsaved changes).
+- `Save`: Saves the file (disabled/greyed out if there are no unsaved changes).
+- `Save As`: Allows you to save the current file under a new name.
 - `Open Into >`:
-  - `Open Containing Folder in Explorer`: Opens this file's folder in the Windows Explorer
-  - `Open Containing Folder in cmd`: Opens this file's folder in the `cmd` command prompt
-  - `Open Containing Folder as Workspace`: Opens this file's folder as a [Folder as Workspace](../session/#folder-as-workspace)
+  - `Open Containing Folder in Explorer`: Opens this file's folder in the Windows Explorer.
+  - `Open Containing Folder in cmd`: Opens this file's folder in the `cmd` command prompt.
+  - `Open Containing Folder as Workspace`: Opens this file's folder as a [Folder as Workspace](../session/#folder-as-workspace).
   - `Open in Default Viewer`: Opens this file in the default Windows, using the same rules as the [**File > Open in Default Viewer** menu action](../files/#file-menu).
-- `Rename`: Renames this file
-- `Move to Recyle Bin`: Deletes the current file (placing it safely in Window's Recycle Bin)
-- `Reload`: Reloads this file from disk
-- `Print`: Prints this file
-- `Read-Only`: Sets this file's Notepad++\-specific read-only flag (see more in the [**Edit** menu description](../editing/#edit-menu))
-- `Clear Read-Only Flag`: Clears this file's read-only flag for the Windows OS (see more in the [**Edit** menu description](../editing/#edit-menu))
+- `Rename`: Renames this file.
+- `Move to Recyle Bin`: Deletes the current file (placing it safely in Window's Recycle Bin).
+- `Reload`: Reloads this file from disk.
+- `Print`: Prints this file.
+- `Read-Only`: Sets this file's Notepad++\-specific read-only flag (see more in the [**Edit** menu description](../editing/#edit-menu)).
+- `Clear Read-Only Flag`: Clears this file's read-only flag for the Windows OS (see more in the [**Edit** menu description](../editing/#edit-menu)).
 - `Copy to Clipboard >`
-  - `Copy Full File Path`: Copies the full file path (drive, directory, and filename) to the Windows Clipboard
-  - `Copy Filename`: Copies just the filename (no drive or directory) to the Windows Clipboard
-  - `Copy Current Dir. Path`: Copies the file's directory (drive and directory, but not the  filename) to the Windows Clipboard
+  - `Copy Full File Path`: Copies the full file path (drive, directory, and filename) to the Windows Clipboard.
+  - `Copy Filename`: Copies just the filename (no drive or directory) to the Windows Clipboard.
+  - `Copy Current Dir. Path`: Copies the file's directory (drive and directory, but not the  filename) to the Windows Clipboard.
 - `Move Document >`
-  - `Move to Other View`: Moves the tab from one view to the other
-  - `Clone to Other View`: Makes a tab for the same file in the other view
-  - `Move to New Instance`: Moves the tab from this Notepad++ instance to a newly-created instance (only works on named files that have no unsaved changes)
-  - `Open in New Instance`: Makes a tab in a new Notepad++ instance which contains the same file as this tab (only works on named files that have no unsaved changes)
+  - `Move to Other View`: Moves the tab from one view to the other.
+  - `Clone to Other View`: Makes a tab for the same file in the other view.
+  - `Move to New Instance`: Moves the tab from this Notepad++ instance to a newly-created instance (only works on named files that have no unsaved changes).
+  - `Open in New Instance`: Makes a tab in a new Notepad++ instance which contains the same file as this tab (only works on named files that have no unsaved changes).
 - `Apply Color to Tab >` (new to v8.4.6)
   - `Apply Color #`: Applies the indicated color to the highlight portion of the tab bar.  (Applying a different color will _change_ the color, not combine the colors together.  Each tab can only have one color.)
-  - `Remove Color`: Removes the color of the tab, returning to the default color scheme
+  - `Remove Color`: Removes the color of the tab, returning to the default color scheme.
 
 ### Menu Bar
 

--- a/content/docs/other-resources.md
+++ b/content/docs/other-resources.md
@@ -80,14 +80,14 @@ Windows 10 and Windows 11 have a "restartable apps" feature (**Windows Start But
   2. Use <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Page Up</kbd> for previous position and <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Page Down</kbd> for next position.
   ![tabNavMoveRtLft](../images/tabNavMoveRtLft.gif)
 
-- To move a tab from one View to the other, you can use the techniques described in the [Editing > Dual View](../editing/#dual-view) section, including:
+- To move a tab from one View to the other, you can use the techniques described in the [Editing > Dual View](../editing/#dual-view) section or [Views > Move / Clone](../views/#move-clone) section, including:
   1. Use the menus: **View > Move/Clone Current Document > Move to Other View**
   2. Right Click on the tab's title and select **Move to Other View**
   3. Drag the tab's title into the editing pane for that same tab and select **Move to Other View**
   4. If the other View is already visible, drag the tab's title into the editing pane of the other View, and it will move
   ![move2view](../images/move2view.gif)
 
-- To clone a tab from one View into the other, you can use the techniques described in the [Editing > Clone Document](../editing/#dual-view) section, including:
+- To clone a tab from one View into the other, you can use the techniques described in the [Editing > Clone Document](../editing/#dual-view) or [Views > Move / Clone](../views/#move-clone) section section, including:
   1. Use the menus: **View > Move/Clone Current Document > Clone to Other View**
   2. Right Click on the tab's title and select **Clone to Other View**
   3. Drag the tab's title into the editing pane for that same tab and select **Clone to Other View**

--- a/content/docs/views.md
+++ b/content/docs/views.md
@@ -97,7 +97,7 @@ The **Zoom** sub-menu will allow you to **Zoom In** (enlarge the text), **Zoom O
 
 ## Move / Clone
 
-The **Move/Clone Current Document** submenu will allow you to affect where the current document is viewed -- either to allow [editing files side-by-side](../editing/dual-view), or editing in a separate instance of Notepad++ (using a completely separate window).
+The **Move/Clone Current Document** submenu will allow you to affect where the current document is viewed -- either to allow [editing files side-by-side](../editing/#dual-view), or editing in a separate instance of Notepad++ (using a completely separate window).
 
 ### Move / Clone to Other View
 

--- a/content/docs/views.md
+++ b/content/docs/views.md
@@ -97,13 +97,13 @@ The **Zoom** sub-menu will allow you to **Zoom In** (enlarge the text), **Zoom O
 
 ## Move / Clone
 
-The **Move/Clone Current Document** submenu will allow you to affect where the current document is viewed.
+The **Move/Clone Current Document** submenu will allow you to affect where the current document is viewed -- either to allow [editing files side-by-side](../editing/dual-view), or editing in a separate instance of Notepad++ (using a completely separate window).
+
+### Move / Clone to Other View
 
 If you **Move to Other View**, the current file will be moved from one View to the other.  If there is currently only one View visible, this command will make the second View visible -- it may be to the right, below, to the left, or above the original View, depending on where the second view was last placed.  You can also accomplish this **Move to Other View** by dragging the tab from one View's tab-bar to the other, or right clicking on the tab and choosing the **Move to Other View** from that menu.
 
 If you **Clone to Other View**, the current file will be visible in both Views at the same time.
-
-If the current file is currently not modified (so no unsaved changes), you can also either **Move to New Instance** or **Clone to New Instance**, which will move the active file from this instance to a new instance of Notepad++, or make this file open in both the current Notepad++ and a new instance of Notepad++.  This will work to create a new instance of Notepad++ even if the [**Settings > Preferences > Multi-Instance**](../preferences/#multi-instance) is set to "mono-instance".
 
 To change the arrangement of the Views, right-click on the dotted bar between the two Views, and **Rotate Right** or **Rotate Left**, which will change the orientation from side-to-side to above-and-below.  Given the four possible arrangements of "File A" and "File B" in separate views shown below, doing **Rotate Right** will go in the sequence 1→2→3→4→1→..., and **Rotate Left** will go in the sequence 1→4→3→2→1→...  (The sequence repeats, and will start from whatever state you are currently in.)
 
@@ -113,6 +113,13 @@ Sequence | Arrangement | Notes
 2 | ![](../images/view-rotate-2.png) | TOP:"File A", BOTTOM:"File B"
 3 | ![](../images/view-rotate-3.png) | RIGHT:"File A", LEFT:"File B"
 4 | ![](../images/view-rotate-4.png) | BOTTOM:"File A", TOP:"File B"
+
+If there's only one View visible, dragging from the tab bar into the current View's editor panel will pop up a context menu that allows either moving or cloning to the other View as well.  Other ways to interact with the tab bar and Views can be found in [Other Resources > Tabs](../other-resources/#tabs).
+
+### Move / Clone to New Instance
+
+If the current file is currently not modified (so no unsaved changes), you can also either **Move to New Instance** or **Clone to New Instance**, which will move the active file from this instance to a new instance of Notepad++ (that is, a separate window rather than just another panel in the current window), or make this file open in _both_ the current Notepad++ _and_ a new instance of Notepad++.  This will work to create a new instance of Notepad++ even if the [**Settings > Preferences > Multi-Instance**](../preferences/#multi-instance) is set to "mono-instance".
+
 
 ## Tab
 


### PR DESCRIPTION
- Add new subsections for Move/Clone, to disambiguate "... to Other View" from "... to New Instance"
- Add crosslinks between **Views > Move / Clone**, **Editing > Dual View**, and **Other Resources > Tabs**
- Also updated the capitalization and full-stops in **Other Resources > Tabs** bulleted and numbered lists to be consistent with other recent edits.

closes #587 