### PR TITLE
Continuous Deployment

### DIFF
--- a/.github/workflows/CD_publish.yml
+++ b/.github/workflows/CD_publish.yml
@@ -1,24 +1,24 @@
-name: Deploy Online User Manual Website
+name: CD_Publish
 
 on:
+  #workflow_run:
+  #  workflows: CI_build
+  #  branches: master
+  #  types: completed
+  ##... the if below would start with `github.event.workflow_run_conclusion == 'success' &&`
   push:
-    tags:
-      - '*'
+    branches:
+      - 'master'
+
   workflow_dispatch:
 
 jobs:
-  build:
-    name: Deploying Online User Manual Website
+  deploy:
+    name: Continuous Deployment: Publish Online User Manual Website
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'notepad-plus-plus' }}
 
     steps:
-    - name: check
-      working-directory: .
-      run: |
-        pwd
-        which ssh
-        which sftp
-
     - name: 🚚 Checkout repo
       uses: actions/checkout@v4
 
@@ -42,12 +42,3 @@ jobs:
           delete_remote_files: false
           local_path: './public/*'
           remote_path: '/var/www/npp-user-manual.org/public_html/'
-
-    #- name: check
-    #  working-directory: .
-    #  run: |
-    #    printf "%s" "${{ secrets.USERMANUAL_KEY }}" >../private_key.pem
-    #    chmod 600 ../private_key.pem
-    #    ls -latr ./public
-    #    ls -latr ..
-    #    ssh -o StrictHostKeyChecking=no -p ${{ secrets.USERMANUAL_PORT }} -i ../private_key.pem ${{ secrets.USERMANUAL_USERNAME }}@${{ secrets.USERMANUAL_HOST }} ls -latr /var/www/npp-user-manual.org/public_html/

--- a/.github/workflows/CD_publish.yml
+++ b/.github/workflows/CD_publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   deploy:
-    name: Continuous Deployment: Publish Online User Manual Website
+    name: Continuous Deployment to Publish Online User Manual Website
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'notepad-plus-plus' }}
 

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - name: Checkout repo
+    - name: 🚚 Checkout repo
       uses: actions/checkout@v4
 
-    - name: Install hugo extended and httrack via chocolatey
+    - name: 📡 Install hugo extended and httrack via chocolatey
       working-directory: .
       run: |
            choco install hugo-extended --version 0.57.2
            choco install httrack
 
-    - name: Retrieve data from server
+    - name: 🔨 Build static HTML for site
       working-directory: .
       run: |
            cmd /c start hugo.exe server --theme book
@@ -30,15 +30,15 @@ jobs:
                $tmpname = "$($orgname).unedited"
                echo $tmpname
                Copy-Item $orgname $tmpname
-               get-content $tmpname | 
-                    %{$_ -replace 'id="book-search-input" maxlength="64" readonly','id="book-search-input" maxlength="64" readonly hidden'} | 
-                    %{$_ -replace 'href="http://localhost:1313/"','href="./index.html"'} | 
-                    %{$_ -replace 'href="http://localhost:1313/','href="'} | 
+               get-content $tmpname |
+                    %{$_ -replace 'id="book-search-input" maxlength="64" readonly','id="book-search-input" maxlength="64" readonly hidden'} |
+                    %{$_ -replace 'href="http://localhost:1313/"','href="./index.html"'} |
+                    %{$_ -replace 'href="http://localhost:1313/','href="'} |
                     set-content $orgname
                Remove-Item $tmpname
            }
 
-    - name: Archive artifacts for hugo
+    - name: 🎉 Store zipfile as artifact
       uses: actions/upload-artifact@v4
       with:
           name: nppUserManual

--- a/.github/workflows/onRelease_zip_manual_as_asset.yml
+++ b/.github/workflows/onRelease_zip_manual_as_asset.yml
@@ -14,16 +14,16 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - name: Checkout repo
+    - name: 🚚 Checkout repo
       uses: actions/checkout@v4
 
-    - name: Install hugo-extended and httrack via chocolatey
+    - name: 📡 Install hugo-extended and httrack via chocolatey
       working-directory: .
       run: |
            choco install hugo-extended --version 0.57.2
            choco install httrack
 
-    - name: Convert hugo site to standandalone HTML
+    - name: 🔨 Build static HTML for site
       working-directory: .
       run: |
            cmd /c start hugo.exe server --theme book
@@ -36,17 +36,17 @@ jobs:
                $tmpname = "$($orgname).unedited"
                echo $tmpname
                Copy-Item $orgname $tmpname
-               get-content $tmpname | 
-                    %{$_ -replace 'id="book-search-input" maxlength="64" readonly','id="book-search-input" maxlength="64" readonly hidden'} | 
-                    %{$_ -replace 'href="http://localhost:1313/"','href="./index.html"'} | 
-                    %{$_ -replace 'href="http://localhost:1313/','href="'} | 
+               get-content $tmpname |
+                    %{$_ -replace 'id="book-search-input" maxlength="64" readonly','id="book-search-input" maxlength="64" readonly hidden'} |
+                    %{$_ -replace 'href="http://localhost:1313/"','href="./index.html"'} |
+                    %{$_ -replace 'href="http://localhost:1313/','href="'} |
                     set-content $orgname
                Remove-Item $tmpname
            }
            Compress-Archive -Path nppUserManual -DestinationPath nppUserManual.zip
            Set-Location -Path ..
 
-    - name: Store zipfile as asset
+    - name: 🎉 Store zipfile as asset
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changed the publish-to-website so it will automatically happen anytime something is pushed to the master branch of the notepad-plus-plus/npp-usermanual (but won't try to publish when someone pushes to the master of their fork).

This should keep the Online User Manual fully up-to-date with fixes to the docs, without requiring a new tag on things like typo fixes.