### PR TITLE
v8.6.3: new Preferences Enable Copy/Cut Line without selection

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -6,7 +6,7 @@ type: docs
 Notepad++ User Manual
 =======
 
-This **Notepad++ User Manual** describes the Notepad++ application v8.x (currently up to v8.6.2).  
+This **Notepad++ User Manual** describes the Notepad++ application v8.x (currently up to v8.6.3).
 
 The documentation is built collaboratively, and [your contribution is very welcome](https://github.com/notepad-plus-plus/npp-usermanual).
 

--- a/content/docs/editing.md
+++ b/content/docs/editing.md
@@ -352,7 +352,7 @@ Certain keyboard-shortcuts for editing commands are "context aware", meaning tha
 
 Again, this manual will not enumerate all the context-aware commands.  The ones listed above have been deemed especially useful, or are mentioned because they were added to give Notepad++ behavior that is similar to other popular text editors and coding environments.
 
-In order to disable the context-aware "line copy / cut / delete" feature, create the [zero-byte config file](../config-files/#other-configuration-files) `disableLineCopyCutDelete.xml` (new to v8.6.1).
+In v8.6.1, you can disable the context-aware "line copy / cut / delete" feature, by creating the [zero-byte config file](../config-files/#other-configuration-files) `disableLineCopyCutDelete.xml`.  This zero-byte config file was eliminated in v8.6.2, so the feature could not be disabled in that version.  And in v8.6.3, **[Settings > Preferences > Editing](../preferences/#editing) > ☐ Enable Copy/Cut Line without selection** was added to be able to control this behavior using the Preferences dialog.
 
 ### Drag-and-Drop Move or Copy
 

--- a/content/docs/preferences.md
+++ b/content/docs/preferences.md
@@ -90,7 +90,8 @@ These influence editing (carets, code-folding, line wrapping, and more).
 * `☐ Enable Multi-Editing`: Allows multiple selections not necessarily contiguous with each other by using `Ctrl`+Mouse click on the selection(s).  (This option is removed in v8.6 and beyond, because `Ctrl`+Mouse multi-editing is now always available.)
 * `☐ Enable scrolling beyond last line`: Allows you to scroll (with scroll bar or mouse wheel) so that up to a page of blank space _after_ the last line is visible.  (When unchecked, scrolling to the end will put the last line of text as the bottom line in the window, when there are more lines of text than are visible in the window.)
 * `☐ Keep selection when right-click outside of selection`: Prevents right-click from cancelling an active selection.
-* `☐ Disable advanced scrolling feature (if you have touchpad problem)`: designed to help if you have a problem with your touchpad
+* `☐ Disable advanced scrolling feature (if you have touchpad problem)`: designed to help if you have a problem with your touchpad.
+* `☐ Enable Copy/Cut Line without selection`: When checkmarked, will allow the [Context Aware Copy/Cut](../editing/#context-awareness) feature to have Copy/Cut shortcuts work with the whole line if there is no active selection.  When it's not checkmarked, doing a Copy or Cut without a selection will not affect the text or clipboard.  (New preference in v8.6.3.)
 
 ### Dark Mode
 


### PR DESCRIPTION
(based on v8.6.3-RC)

From my initial reading of the [Release Candidate Announcement](https://community.notepad-plus-plus.org/topic/25469/notepad-v8-6-3-release-candidate), this is the only documentation change needed for v8.6.3.