### PR TITLE
UserInterface: clarify Toolbar > Show All Characters

### DIFF
--- a/content/docs/user-interface.md
+++ b/content/docs/user-interface.md
@@ -125,7 +125,7 @@ There is a toolbar which has icons for various common tasks, which each run a sp
 - **Synchronize Horizontal Scrolling** ⇒ [**View > Synchronize Horizontal Scrolling**](../views/#synchronized-scrolling): Toggle locking of the two views together, horizontally.
 - **Word Wrap** ⇒ [**View > Word Wrap**](../views/#wrapping): Toggle whether or not long lines will be wrapped in the display.
 - **Show All Characters** ⇒ [**View > Show Symbol > Show All Characters**](../views/#show-symbol): Toggle showing all special characters.
-    - Starting in v8.6.9, there is a drop-down menu available from this toolbar icon.  Clicking the button will still toggle from showing all to showing none.  But if you click the drop-down instead, you see the full [**View > Show Symbol**](../views/#show-symbol) submenu, from which you can manually select which special characters to show and which not to.
+    - Starting in v8.6.9, there is a drop-down menu available from this toolbar icon.  Clicking the button will still toggle from showing all to showing none.  But if you click the drop-down instead (or right click anywhere on the icon), you will see the full [**View > Show Symbol**](../views/#show-symbol) submenu, from which you can manually select which special characters to show and which not to.
 - **Show Indent Guide** ⇒ [**View > Show Symbol > Show All Characters**](../views/#show-symbol): Toggle dotted vertical line `⸽` showing tabstops.
 - **Define Your Language** ⇒ [**Language > User Defined Language > Define Your Language**](..//user-defined-language-system/): Toggles dialog to define a User Defined Language ("UDL").
 - **Document Map** ⇒ [**View > Document Map**](/views/#panels): Toggles display of the Document Map panel.


### PR DESCRIPTION
add right click, not just clicking on the pulldown symbol

ref: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/15440#issuecomment-2237362900