### PR TITLE
Add instructions for how to enable a hidden lexer

### DIFF
--- a/content/docs/programing-languages.md
+++ b/content/docs/programing-languages.md
@@ -44,7 +44,7 @@ syntax highlight extremely large files.  This threshold is configurable in
 ### JavaScript
 
 Internally, there are actually two entries for JavaScript: in the [Style Configurator](../preferences/#style-configurator),
-these show up as "JavaScript" and "JavaScript (embedded)".  The first is for standalone JavaScript files (usually with `.js` 
+these show up as "JavaScript" and "JavaScript (embedded)".  The first is for standalone JavaScript files (usually with `.js`
 extension); the second is for when JavaScript is embedded in an HTML file -- so you can actually have different color rules
 for when the JavaScript is inside HTML and when it's a separate file.  (In the [`langs.xml`](../config-files/#keyword-lists-langsxml)
 and [`stylers.xml`](../config-files/#highlighting-schemes-stylersxml) config files, the standalone uses `name="javascript.js"`.)
@@ -54,19 +54,76 @@ If you manually pick **Language > J > JavaScript**, the active file will use the
 ### Themes and Language Support
 
 There are times when a particular Theme will not have been updated to include syntax highlighting for a given Language.
-If a Language you need is missing in your chosen Theme, you can open `%AppData%\Notepad++\stylers.xml` (if you use the 
-default theme) or the appropriate `%AppData%\Notepad++\themes\______.xml` file for your Theme, 
-plus the `C:\Program Files\Notepad++\stylers.model.xml` (the locations of both those file can vary depending on your active 
+If a Language you need is missing in your chosen Theme, you can open `%AppData%\Notepad++\stylers.xml` (if you use the
+default theme) or the appropriate `%AppData%\Notepad++\themes\______.xml` file for your Theme,
+plus the `C:\Program Files\Notepad++\stylers.model.xml` (the locations of both those file can vary depending on your active
 [Config Files Location](../config-files/#configuration-files-location) for `themes\______.xml`, and your `notepad++.exe` executable's
-directory for the `stylers.model.xml`, if you are not using a default installation).  Search in `stylers.model.xml` for the 
+directory for the `stylers.model.xml`, if you are not using a default installation).  Search in `stylers.model.xml` for the
 `<LexerType...>` section for the missing Language, and copy that over to the appropriate location in your `themes\______.xml`.
 Close Notepad++ completely and re-run it: that Language should now be in the [Style Configurator](../preferences/#style-configurator)
 for your active theme, though depending on how different your Theme's color scheme is compared to the Default Theme, the colors
-may be jarring compared to your Theme's background color; but once it's in the Style Configurator, you may update the color scheme for 
-that Language in the Style Configurator. (If your Theme is a dark Theme, it might be better to copy from `themes\DarkModeDefault.xml` 
+may be jarring compared to your Theme's background color; but once it's in the Style Configurator, you may update the color scheme for
+that Language in the Style Configurator. (If your Theme is a dark Theme, it might be better to copy from `themes\DarkModeDefault.xml`
 instead of copying from `stylers.model.xml`.)
 
 Similarly, the Style Configurator lists Default Keyword Lists for the styles of some languages: those are defined in `%AppData%\Notepad++\langs.xml`, and the defaults are in `C:\Program Files\Notepad++\langs.model.xml`.  If `langs.model.xml` has been updated, then you can copy the updated or added keyword lists from there into your `langs.xml`.
+
+### Contribution: Enable Lexilla Lexer That Is Not Active In Notepad++
+
+The [Lexilla library](https://github.com/ScintillaOrg/lexilla/) which Notepad++ uses for syntax highlighting has many languages available to it that Notepad++ doesn't yet provide in the **Language** menu and Style Configurator.  In general, just creating an [issue](https://github.com/notepad-plus-plus/notepad-plus-plus/issues) to request a language be enabled is not sufficient to get it added, because the developers don't have sufficient knowledge of all Lexilla-enabled languages to know if the addition was successful or not; you should put in the request if there's a language in Lexilla that you would like added to Notepad++, but, if possible, you could also put in the Pull Request.  (While it's not sufficient, creating the issue _is_ a [necessary first step](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/CONTRIBUTING.md), because the developer generally does not merge Pull Requests that aren't attached to an existing open issue.)
+
+Creating a PR yourself to enable a not-yet-active lexer should only be attempted if you are familiar with the GitHub environment and the git system of version control, and are comfortable developing in C++.  If this is something that you are ready to do, the following are all pieces of the codebase that need to be updated in order to activate a currently-inactive lexer. For this description, "Xyz Pdq" will be the placeholder name of your language; you, of course, need to use your own language's name instead of the placeholder.
+
+- `PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h`:
+    - Need to add an `L_XYZPDQ` constant for your language to the end of the `enum LangType`
+    - Insert it between the last real language in the list and `L_EXTERNAL`; **never** insert it before an already-existing language, as the position in the list gives it an integer that is used throughout the codebase and config files.
+- `PowerEditor/src/menuCmdID.h`:
+    - Add `#define IDM_LANG_XYZPDQ` between the last existing language and `IDM_LANG_EXTERNAL`, using the next integer for the value (the `L_XYZPDQ` from the enum should be in that same integer slot in the enum)
+- `PowerEditor/src/ScintillaComponent/ScintillaEditView.h`
+    - declare `setXyzPdqLexer()`
+    - if it's a simple lexer, which just needs to define one or more keyword lists, you can define it here instead of in the `.cpp` below, just calling `setLexer(L_XYZPDQ, LIST_0 | LIST_1 | ...);`, similar to what was done for `setHollywoodLexer()`
+    - An aside on the keyword lists: The `lexilla/Lexers/LexXyzPdq.cxx` will contain one or more `WordList` variables; usually in `LexerXyzPdq::WordListSet()`, you will see a mapping between the word list index and th `WordList` variable.  That index corresponds to the `LIST_#` constant used when calling `setLexer()`.
+- `PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp`
+    - add the language to `LanguageNameInfo ScintillaEditView::_langNameInfoArray[]`, just before the `L_EXTERNAL` entry.  The table below describes that value that needs to go in each column of that data structure.
+        | Column       | Example        | Description |
+        |--------------|----------------|-------------|
+        | `_langName`  | `xyzpdq`       | Unique string to identify the language.  Will be used as the `<Language name="xyzpdq" ... />` attribute in `langs.xml` |
+        | `_shortName` | `Xyz Pdq`      | This is the text that appears in the **Languages** menu |
+        | `_longName`  | `Xyz Pdq file` | This is the text that appears in the **Status Bar**'s file type field |
+        | `_langID`    | `L_XYZPDQ`     | This is the `L_XYZPDQ` entry you added to the enum |
+        | `_lexerID`   | `xyzpdq`       | This is the name of the lexer, as defined in the `lexilla/Lexers/LexXyzPdq.cxx`, in the `LexerModule` instantiation |
+    - add your language to the big `switch` block in `ScintillaEditView::defineDocType()`; it should call `setXyzPdqLexer(); break`
+    - add in the definition for your `setXyzPdqLexer()`
+        - If it's just calling `setLexer()`, you can actually define it in the `.h`, as described above.
+        - If it requires complicated logic, define it here, instead.
+        - If the lexer includes SubStyle keyword capability, you can either initialize them in the optional end arguments of the `setLexer()` call (see `setLuaLexer()` and `setPythonLexer()` in the `.h` for examples of how to use those optional arguments), or your more-complicated definitions may call `populateSubStyleKeywords()` themselves, like `ScintillaEditView::setTypeScriptLexer()` does)
+            - if you are unsure whether your language has substyles, just search the `lexilla/Lexers/LexXyzPdq.cxx` for the word `SubStyle`; with some digging in the code, you should be able to determine which Style the SubStyles get attached to, as well.
+- `PowerEditor/src/Notepad_plus.cpp`:
+    - in the switch in `Notepad_plus::menuID2LangType()`, add
+        ```
+        case IDM_LANG_XYZPDQ:
+            return L_XYZPDQ;
+        ```
+- `PowerEditor/src/Parameters.cpp`:
+    - in the switch in `NppParameters::langTypeToCommandID()`, add
+        ```
+        case L_XYZPDQ:
+            id = IDM_LANG_XYZPDQ; break;
+        ```
+- `PowerEditor/src/Notepad_plus.rc`:
+    - add a `MENUITEM` in the alphabetically correct place in both the `&Language` big-list, and the `&Language`/`POPUP "X"` per-letter version.
+- `PowerEditor/src/NppCommands.cpp`:
+    - `Notepad_plus::command()` has a huge switch; add `case IDM_LANG_XYZPDQ:` to the big list of similar `case IDM_LANG_...` entries
+
+And add in config files:
+- `PowerEditor/src/langs.model.xml`: add in your `<Language name="xyzpdq"...>` entry with its `<Keywords ...>` entries
+    - the `name="instre1"` is the keyword list for `LIST_0`, `instre2` for `LIST_1`, and `type1`-`type7` are `LIST_2`-`LIST_8`; `substyle1`-`substyle8` are for the eight substyles that Notepad++ allows (if the lexer has enabled substyles, of course).
+- `PowerEditor/src/stylers.model.xml` and all of the `PowerEditor/installer/themes/*.xml`: add in your `<LexerType name="xyzpdq"...>` with its `<WordsStyles>` entries
+    - `lexilla/include/SciLexer.h` has `#define` for `#define SCI_XYZPDQ_* N` values; you will need to make sure you have a `<WordsStyle ... styleID="N" ...>` for each of those styles.
+
+You should also include [autoCompletion](../auto-completion/) definition and [functionList](../function-list/) definition if you have them (they are optional, but highly recommended).  If you submit a functionList, please remember to also create the [unit tests](../function-list/#contribute-your-new-or-enhanced-parser-rule-to-the-notepad-codebase) required to accompany new functionList parsers.
+
+Once you have thoroughly tested your code updates, and verified that it can properly syntax-highlight the newly-enabled language, then you can submit your PR to the [repository](https://github.com/notepad-plus-plus/notepad-plus-plus/) and link it to the issue that you had already created.
 
 ## Language Detection Priority
 


### PR DESCRIPTION
In 2019, when [this comment](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/3292#issuecomment-531320436) was made, I didn't know how to enable a Lexer, and none of the other participants of that discussion volunteered with instructions.  Since I have since learned how (and successfully enabled the Go and Raku lexers), I translated my notes from that process to add to the User Manual.