### PR TITLE
Correct kab command-prompt.md

### DIFF
--- a/content/docs/command-prompt.md
+++ b/content/docs/command-prompt.md
@@ -84,7 +84,7 @@ code | file
 `it`, `it-ch` | `italian.xml`
 `ja` | `japanese.xml`
 `ka` | `georgian.xml`
-`keb` | `kabyle.xml`
+`kab` | `kabyle.xml`
 `kk` | `kazakh.xml`
 `kn` | `kannada.xml`
 `ko`, `ko-kp`, `ko-kr` | `korean.xml`


### PR DESCRIPTION
Correct mistyping of `kab` for Kabyle.