### PR TITLE
Revert "Correct kab command-prompt.md"

### DIFF
--- a/content/docs/command-prompt.md
+++ b/content/docs/command-prompt.md
@@ -84,7 +84,7 @@ code | file
 `it`, `it-ch` | `italian.xml`
 `ja` | `japanese.xml`
 `ka` | `georgian.xml`
-`kab` | `kabyle.xml`
+`keb` | `kabyle.xml`
 `kk` | `kazakh.xml`
 `kn` | `kannada.xml`
 `ko`, `ko-kp`, `ko-kr` | `korean.xml`


### PR DESCRIPTION
Reverts notepad-plus-plus/npp-usermanual#737

Notepad++ source code actually [uses the incorrect `keb` spelling](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/10ae99e7909ed26b06f55f1edb5396a7acd481a0/PowerEditor/src/Parameters.cpp#L4710-L4711) for that command-line argument value.