### PR TITLE
TabBar ContextMenu cross-link

### DIFF
--- a/content/docs/config-files.md
+++ b/content/docs/config-files.md
@@ -120,7 +120,7 @@ In brief, the structure of the context menu file is as follows
 
 ## The context menu: `tabContextMenu.xml`
 
-Starting in v8.4.8, the tab-bar context menu (the menu that you see when you right-click on the title of the tab in the tab bar) is user-configurable using the `tabContextMenu.xml` config file.
+Starting in v8.4.8, the [tab-bar context menu](user-interface/#tab-bar-right-click-menu) (the popup menu that you see when you right-click on the title of the tab in the tab bar) is user-configurable using the `tabContextMenu.xml` config file.
 
 The format is the same as the `contextMenu.xml` described [above](#context-menu-syntax-summary), except the "Intermediate Node" is `<TabContextMenu>` instead of `<ScintillaContextMenu>`.
 

--- a/content/docs/user-interface.md
+++ b/content/docs/user-interface.md
@@ -77,6 +77,8 @@ If the description says it will "wrap", it means that if you try to go beyond th
 
 When you right click on the title for a tab, you get a context menu for manipulating that tab.
 
+By default, the commands available in that context menu are described below.  If you would like to add other commands to that context menu, or remove commands you don't want to "clutter" that context menu, you can follow the instructions for [customizing the tab context menu using `tabContextMenu.xml`](config-files/#the-context-menu-tabcontextmenuxml).
+
 - `Close`: Closes this file's tab.
 - `Close Multiple Tabs >`:
   - `Close All BUT This`: Closes all files, except this tab's file.


### PR DESCRIPTION
Add link from UI:TabBar to ConfigFiles:tabContextMenu and vice versa

per: <https://community.notepad-plus-plus.org/topic/26648/suggestion-view-tab-move-up-down>, it wasn't clear in the UI section that it's customizable.