### PR TITLE
-pluginMessage argument conventions

### DIFF
--- a/content/docs/command-prompt.md
+++ b/content/docs/command-prompt.md
@@ -173,6 +173,9 @@ code | file
 * `-titleAdd="additional title bar text"`: Add a dash and a space and the supplied text to the right side of the application title bar (new to v8.0.0).
 * `-pluginMessage="text for plugin(s)"`: If plugin developers need extra command line arguments, then users can add this option, and the plugin will be [notified](../plugin-communication/#NPPN_CMDLINEPLUGINMSG "NPPN_CMDLINEPLUGINMSG") that it can parse that string for extra information (new to v8.4.2).
     - You can only give Notepad++ _one_ `-pluginMessage` argument.  If you have multiple pieces of information you want to pass to one or more plugins, they have to be joined together, such as, `-pluginMessage="arg1=Val1;arg2=Val2"`, and the plugin has to know how to split the contents of that message into the pieces that the plugin needs.
+    - Every plugin defines their own usage of the message.
+        - Plugin users will need to check the documentation for the specific plugin to see what exact synatax it wants.
+        - Plugin authors are [encouraged](../plugin-communication/#NPPN_CMDLINEPLUGINMSG "NPPN_CMDLINEPLUGINMSG") to use the example above as a guideline and convention for how to interpret their portion of the `-pluginMessage` , to make sure that multiple plugins would be able to handle their own portions of the `-pluginMessage` string, without interfering with each other.
 * `filepath`: File or folder name to open (absolute or relative path name).
 
 The order of the options is not important.  Brackets indicate that the options

--- a/content/docs/plugin-communication.md
+++ b/content/docs/plugin-communication.md
@@ -2393,7 +2393,6 @@ The general layout of the following notifications look like this
 	If **_idFrom_** is shown as `0` or `NULL`, then that notification does not use this Field.  If **_idFrom_** needs a different value for a notification, a full description will be provided.
 
 ---
----
 
 #### [1019] **NPPN_BEFORESHUTDOWN**
 *To notify plugins that Notepad++ shutdown has been triggered, files have not been closed yet*
@@ -2436,6 +2435,16 @@ The general layout of the following notifications look like this
 	code:		NPPN_CMDLINEPLUGINMSG
 	hwndFrom:	hwndNpp
 	idFrom:		pluginMessage, where pluginMessage is pointer of type wchar_t
+
+**Recommendation**: Multiple plugins might be wanting to make use of the one `-pluginMessage` command-line argument.  To "play nice" with the other plugins, please follow these conventions from this example command-line option: `-pluginMessage="PluginOne=Val1;DifferentPlugin=Val2"`
+- Each plugin should preface its section of the message string with the plugin name (or other uniquely-identifying information)
+    - If a plugin wants multiple sections of a string, it could do something like `-pluginMessage="PluginOne:arg1=Val1;DifferentPlugin=Val2;PluginOne:arg2=Val3"`, and just pay attention to the two sections that start with its name.
+	- Alternately, something like `-pluginMessage="PluginOne={keyA:valA, keyB:valB};DifferentPlugin=Val2"` would also be reasonable.
+- It is easier to read if an `=` is used inside the string to join the name of the plugin to the remainder of the text it wants to use
+- Each plugin should treat `;` as a separator between one plugin's portion and another (so PluginOne should ignore everything from the `;` onward, and DifferentPlugin should ignore everything before the `;`)
+- It is a bad idea to assume that yours is the only plugin using this command-line argument, and ignoring this convention will likely make things more difficult for users of your plugin.
+
+Using the plugin name as the prefix and the `;` separator will prevent one plugin from accidentally misinterpreting another plugin's expected text.  As long as a plugin's parsing honors these primary aspects of the convention, it is likely to "play nice" with others.
 
 ---
 


### PR DESCRIPTION
better describe the convention implied by the example in the command-line argument description, both from the user's perspective (in command-prompt.md) and from the plugin author's perspective (plugin-communication.md)

per https://github.com/notepad-plus-plus/notepad-plus-plus/issues/17022#issuecomment-3324352948