### PR TITLE
Update Delphi plugin template's host URL

### DIFF
--- a/content/docs/plugins.md
+++ b/content/docs/plugins.md
@@ -127,8 +127,7 @@ for any technical questions/answers and the announcement of your new plugin.
   - [NppCSharpPluginPack](https://github.com/molsonkiko/NppCSharpPluginPack) - Mark Olson's fork of the original "kblisted" pack, with improvements and active maintenance.
   - [Npp.DotNet.Plugin](https://www.nuget.org/packages/Npp.DotNet.Plugin) - AOT-compatible port of the .NET Framework plugin template for Notepad++.
 * [D](https://gitlab.com/dokutoku/npp-api)
-* Delphi:
-  - [Modern (32-bit/64-bit)](https://bitbucket.org/rdipardo/delphiplugintemplate/get/default.zip): This version has the headers necessary to work with Notepad++ v8.3.3 and newer.
+* [Delphi / Lazarus](https://github.com/rdipardo/delphiplugintemplate#readme)
 
 ### Header Files
 


### PR DESCRIPTION
Atlassian has begun impoverishing Bitbucket's free tier to the point that I no longer trust it as a primary host (e.g., issue trackers and wikis have been disabled, and all associated data will [soon be deleted](https://community.atlassian.com/forums/Bitbucket-articles/Announcing-sunset-of-Bitbucket-Issues-and-Wikis/ba-p/3193882)).

I also took the liberty of tidying up the template description, since there's really no viable alternative any longer. 

