### PR TITLE
Revise Plugins Admin buttons for installed, incompatible, and deactivated plugins

### DIFF
--- a/content/docs/plugins.md
+++ b/content/docs/plugins.md
@@ -85,10 +85,10 @@ The Plugins Admin has five tabs:
 
 - **Available** ⇒ Shows plugins you haven't yet installed, and gives an **Install** button
 - **Updates** ⇒ Shows plugins you have installed but that Plugins Admin knows have updates available, and gives an **Update** button
-- **Installed** ⇒ Shows plugins you have installed, and gives a **Remove** button
-- **Incompatible** ⇒ Shows plugins you had previously installed but are no longer compatible with Notepad++:
+- **Installed** ⇒ Shows plugins you have installed, and gives **Deactivate** and **Remove** buttons
+- **Incompatible** ⇒ Shows plugins you had previously installed but are no longer compatible with Notepad++, and gives a **Remove** button:
   - check with that plugin's website to see if they've released a version that is compatible that just hasn't made it to Plugins Admin yet
-- **Deactivated** ⇒ Shows plugins you had previously deactivated.
+- **Deactivated** ⇒ Shows plugins you had previously deactivated, and gives **Activate** and **Remove** buttons.
 
 The Plugins Admin window also shows the Plugin List version and links to the Plugin List repository (new to v8.4.6).
 

--- a/content/docs/plugins.md
+++ b/content/docs/plugins.md
@@ -105,7 +105,7 @@ Actions available through the Plugins
     - This button is visible when you are in the **Updates** tab.
     - Checkmark the plugin(s) you want to deactivate, and click **Update**.
         - Notepad++ will install the more-recent version of the plugin, then restart.
-- **Deactivate**: Allows you to deactivate one or more plugins using the GUI.
+- **Deactivate**: Allows you to deactivate one or more plugins using the GUI. Deactivated plugins remain in the program’s folder but are not loaded at startup, thereby reducing memory usage and decluttering the interface.
     - This button is visible when you are in the **Installed** tab.
     - Checkmark the plugin(s) you want to deactivate, and click **Deactivate**.
         - Notepad++ will move the plugin files to the `disabled\` subfolder, and then restart; those plugins will now be listed in the **Deactivated** tab, not the **Installed** tab.

--- a/content/docs/plugins.md
+++ b/content/docs/plugins.md
@@ -105,7 +105,7 @@ Actions available through the Plugins
     - This button is visible when you are in the **Updates** tab.
     - Checkmark the plugin(s) you want to deactivate, and click **Update**.
         - Notepad++ will install the more-recent version of the plugin, then restart.
-- **Deactivate**: Allows you to deactivate one or more plugins using the GUI. Deactivated plugins remain in the program’s folder but are not loaded at startup, thereby reducing memory usage and decluttering the interface.
+- **Deactivate**: Allows you to deactivate one or more plugins using the GUI. Deactivated plugins are moved to another subfolder (see below), and are thus not loaded at startup, thereby reducing memory usage and decluttering the interface.
     - This button is visible when you are in the **Installed** tab.
     - Checkmark the plugin(s) you want to deactivate, and click **Deactivate**.
         - Notepad++ will move the plugin files to the `disabled\` subfolder, and then restart; those plugins will now be listed in the **Deactivated** tab, not the **Installed** tab.


### PR DESCRIPTION
Updated the Plugins Admin section to reflect changes in button functionality for the Installed, Incompatible, and Deactivated tabs. Installed plugins now provide both Deactivate and Remove buttons. Incompatible plugins now provide a Remove button. Deactivated plugins now provide Activate and Remove buttons. These updates ensure that the documentation accurately reflects the current behavior of the Notepad++ interface.