### PR TITLE
fix context menu anchor

### DIFF
--- a/content/docs/config-files.md
+++ b/content/docs/config-files.md
@@ -79,6 +79,8 @@ For the `config.xml` (which contains the settings from the GUI's **Settings > Pr
 # Specifics on Configuration Files
 
 ## The context menu: `contextMenu.xml`
+<a name="the-context-menu-contextmenu-xml"></a>
+
 
 <!-- http://web.archive.org/web/20190518131311/http://docs.notepad-plus-plus.org/index.php/Context_Menu -->
 


### PR DESCRIPTION
per https://github.com/notepad-plus-plus/notepad-plus-plus/issues/18350, N++ is linking to the anchor with a hyphen before xml, while hugo (currently) auto-translates the anchor without that hyphen.  (Hugo apparently changed its anchor-creating rules.)

Make the user manual accept either anchor, so that older versions of the app will work, whether or not the app PR is accepted